### PR TITLE
docs: mermaid support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdoc = "./docs/rustdoc-workspace-shim.sh"

--- a/docs/after-content.html
+++ b/docs/after-content.html
@@ -1,0 +1,9 @@
+<script>
+    mermaid.init({
+        startOnLoad: true,
+        theme: "default",
+        look: "handDrawn",
+        fontFamily: "'Comic Sans MS', 'Comic Sans', 'Comic Neue', arial, sans-serif;" },
+        "pre.language-mermaid > code"
+    );
+</script>

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,0 +1,1 @@
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>

--- a/docs/rustdoc-workspace-shim.sh
+++ b/docs/rustdoc-workspace-shim.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Use absolute paths to the injected HTML to resolve differences in relative paths when rustdoc is
+# invoked from _both_ the WORKSPACE _and_ the CRATE directories for each crate in the workspace, as
+# well as crate dependencies when not using --no-deps
+rustdoc \
+    --html-in-header="$REPO_ROOT/docs/header.html" \
+    --html-after-content="$REPO_ROOT/docs/after-content.html" \
+    "$@"

--- a/libgrease/src/lib.rs
+++ b/libgrease/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod state_machine;

--- a/libgrease/src/state_machine/mod.rs
+++ b/libgrease/src/state_machine/mod.rs
@@ -1,0 +1,14 @@
+//! Finite state machine for Grease payment channels
+//!
+//! ```mermaid
+//! stateDiagram-v2
+//!     [*] --> Still
+//!     Still --> [*]
+//!
+//!     Still --> Moving
+//!     Moving --> Still
+//!     Moving --> Crash
+//!     Crash --> [*]
+//! ```
+//!
+//! # See how it looks


### PR DESCRIPTION
Adds support for mermaid diagrams in docstrings.

e.g.
```
/// ```mermaid
/// stateDiagram-v2
///     [*] --> Still
///     Still --> [*]
///
///     Still --> Moving
///     Moving --> Still
///     Moving --> Crash
///     Crash --> [*]
/// ```
```
produces 

```mermaid
stateDiagram-v2
    [*] --> Still
    Still --> [*]
    Still --> Moving
    Moving --> Still
    Moving --> Crash
    Crash --> [*]
```