### PR TITLE
feat: persisting channel state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ ENV/
 env.bak/
 venv.bak/
 
-
+# test artifacts
+/libgrease/test_data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,21 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +300,9 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake"
@@ -414,20 +402,6 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -1271,30 +1245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core 0.61.0",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,15 +1536,16 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 name = "libgrease"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "blake",
  "blake2",
- "chrono",
  "curve25519-dalek",
  "digest",
  "env_logger",
  "hex",
  "log",
  "rand 0.9.1",
+ "ron",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -2726,6 +2677,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
+dependencies = [
+ "base64",
+ "bitflags 2.9.0",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,7 +3432,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -3592,24 +3555,11 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-strings",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
 ]
 
 [[package]]
@@ -3617,17 +3567,6 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3644,23 +3583,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
@@ -3681,15 +3603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,15 +3610,6 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/libgrease/Cargo.toml
+++ b/libgrease/Cargo.toml
@@ -10,14 +10,15 @@ default = ["dummy_channel"]
 test_features = ["dummy_channel"]     
 
 [dependencies]
+anyhow = { workspace = true }
 blake = "2.0.2"
-chrono = "0.4"
 curve25519-dalek = { version = "4.1.3", features = ["digest"] }
 digest = "0.10.7"
 hex = "0.4.3"
 rand = { workspace = true }
 thiserror = "2.0.12"
 log = "0.4.27"
+ron = "0.10.1"
 serde = { version = "1.0.219", features = ["derive"] }
 
 [dev-dependencies]

--- a/libgrease/src/amount.rs
+++ b/libgrease/src/amount.rs
@@ -5,6 +5,7 @@ use std::ops::{Add, AddAssign, SubAssign};
 pub const PICONERO: u64 = 1_000_000_000_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct MoneroAmount {
     /// The amount of money in the channel
     amount: u64,

--- a/libgrease/src/channel_id.rs
+++ b/libgrease/src/channel_id.rs
@@ -1,8 +1,9 @@
 use crate::state_machine::Balances;
 use digest::Digest;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ChannelId {
     merchant_id: Vec<u8>,
     customer_id: Vec<u8>,
@@ -73,7 +74,7 @@ impl Debug for ChannelId {
 
 impl Display for ChannelId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&self.hashed_id))
+        write!(f, "{}", self.name())
     }
 }
 
@@ -101,7 +102,7 @@ mod test {
         assert_eq!(id.customer(), "customer");
         assert_eq!(id.initial_balance().merchant.to_piconero(), 1_250_000_000_000);
         assert_eq!(id.initial_balance().customer.to_piconero(), 750_000_000_000);
-        assert_eq!(id.to_string(), "a2edd1f8091cc375b12357b427a748ba");
+        assert_eq!(id.to_string(), "XGCa2edd1f8091cc375b12357b427a748ba");
     }
 
     #[test]

--- a/libgrease/src/crypto/keys.rs
+++ b/libgrease/src/crypto/keys.rs
@@ -4,6 +4,7 @@ use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::{EdwardsPoint, Scalar};
 use hex::FromHexError;
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
 
@@ -43,9 +44,28 @@ impl Curve25519Secret {
 
 impl SecretKey for Curve25519Secret {}
 
+impl Serialize for Curve25519Secret {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.as_hex())
+    }
+}
+
 impl From<Scalar> for Curve25519Secret {
     fn from(value: Scalar) -> Self {
         Self(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for Curve25519Secret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let hex_str = String::deserialize(deserializer)?;
+        Curve25519Secret::from_hex(&hex_str).map_err(serde::de::Error::custom)
     }
 }
 
@@ -121,6 +141,25 @@ impl PublicKey for Curve25519PublicKey {
 impl Debug for Curve25519PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_hex())
+    }
+}
+
+impl Serialize for Curve25519PublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.as_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Curve25519PublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let hex_str = String::deserialize(deserializer)?;
+        Curve25519PublicKey::from_hex(&hex_str).map_err(serde::de::Error::custom)
     }
 }
 

--- a/libgrease/src/crypto/traits.rs
+++ b/libgrease/src/crypto/traits.rs
@@ -1,8 +1,9 @@
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
-pub trait SecretKey: Clone {}
+pub trait SecretKey: Clone + Serialize + for<'de> Deserialize<'de> {}
 
-pub trait PublicKey: Clone + PartialEq + Eq {
+pub trait PublicKey: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> {
     type SecretKey: SecretKey;
 
     fn keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (Self::SecretKey, Self);

--- a/libgrease/src/file_store.rs
+++ b/libgrease/src/file_store.rs
@@ -20,11 +20,11 @@ impl FileStore {
     ///
     /// # Arguments
     /// * `path` - The path to the directory where the channel files will be stored.
-    pub fn new(path: PathBuf) -> Self {
+    pub fn new(path: PathBuf) -> Result<Self, std::io::Error> {
         if !path.exists() {
-            fs::create_dir_all(&path).expect("Failed to create directory");
+            fs::create_dir_all(&path)?;
         }
-        Self { path }
+        Ok(Self { path })
     }
 
     /// Returns the path to the directory where the channel files are stored.
@@ -67,7 +67,7 @@ mod test {
     #[test]
     fn test_file_store() {
         let path = PathBuf::from("./test_data");
-        let mut store = FileStore::new(path);
+        let mut store = FileStore::new(path).expect("directory to exist");
         let (mut lc, initial_state) = new_channel_state();
         let name = initial_state.channel_id.name();
         store.write_channel(&lc).expect("Failed to write channel");

--- a/libgrease/src/file_store.rs
+++ b/libgrease/src/file_store.rs
@@ -1,0 +1,97 @@
+use crate::crypto::traits::PublicKey;
+use crate::kes::KeyEscrowService;
+use crate::monero::MultiSigWallet;
+use crate::payment_channel::ActivePaymentChannel;
+use crate::state_machine::traits::StateStore;
+use crate::state_machine::ChannelLifeCycle;
+use ron::ser::PrettyConfig;
+use std::fs;
+use std::path::PathBuf;
+
+/// A file-based store for payment channel state.
+///
+/// Each channel is saved in a file with the channel ID as the filename, e.g. `XGCa2edd1f8091cc375b12357b427a748ba.ron`
+pub struct FileStore {
+    path: PathBuf,
+}
+
+impl FileStore {
+    /// Creates a new file store with the given path.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the directory where the channel files will be stored.
+    pub fn new(path: PathBuf) -> Self {
+        if !path.exists() {
+            fs::create_dir_all(&path).expect("Failed to create directory");
+        }
+        Self { path }
+    }
+
+    /// Returns the path to the directory where the channel files are stored.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+impl<P, C, W, KES> StateStore<P, C, W, KES> for FileStore
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    fn write_channel(&mut self, state: &ChannelLifeCycle<P, C, W, KES>) -> Result<(), anyhow::Error> {
+        let file_path = self.path.join(format!("{}.ron", state.current_state().name()));
+        let config = PrettyConfig::new().compact_arrays(true).compact_maps(true);
+        let val = ron::ser::to_string_pretty(state, config)?;
+        fs::write(&file_path, &val)?;
+        Ok(())
+    }
+
+    fn load_channel(&self, name: &str) -> Result<ChannelLifeCycle<P, C, W, KES>, anyhow::Error> {
+        let file_path = self.path.join(format!("{}.ron", name));
+        let val = fs::read_to_string(&file_path)?;
+        let channel: ChannelLifeCycle<P, C, W, KES> = ron::de::from_str(&val)?;
+        Ok(channel)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::amount::MoneroAmount;
+    use crate::payment_channel::ClosedPaymentChannel;
+    use crate::state_machine::lifecycle::test::*;
+
+    /// Saves and loads the state after every transition. We should be able to carry on as if nothing happened.
+    #[test]
+    fn test_file_store() {
+        let path = PathBuf::from("./test_data");
+        let mut store = FileStore::new(path);
+        let (mut lc, initial_state) = new_channel_state();
+        let name = initial_state.channel_id.name();
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+        lc = accept_proposal(lc, &initial_state);
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+
+        lc = open_channel(lc, &initial_state);
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+
+        lc = payment(lc, MoneroAmount::from_xmr("0.1").unwrap());
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+
+        lc = start_close(lc);
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+
+        lc = successful_close(lc);
+        store.write_channel(&lc).expect("Failed to write channel");
+        lc = store.load_channel(&name).expect("Failed to load channel");
+        let final_balance = lc.closed_channel().unwrap().final_balance();
+        assert_eq!(final_balance.customer, MoneroAmount::from_xmr("1.15").unwrap());
+    }
+}

--- a/libgrease/src/kes/dummy_impl.rs
+++ b/libgrease/src/kes/dummy_impl.rs
@@ -1,5 +1,7 @@
 use crate::kes::KeyEscrowService;
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DummyKes;
 
 impl KeyEscrowService for DummyKes {}

--- a/libgrease/src/kes/traits.rs
+++ b/libgrease/src/kes/traits.rs
@@ -1,1 +1,3 @@
-pub trait KeyEscrowService {}
+use serde::{Deserialize, Serialize};
+
+pub trait KeyEscrowService: Serialize + for<'de> Deserialize<'de> {}

--- a/libgrease/src/lib.rs
+++ b/libgrease/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod amount;
 pub mod channel_id;
 pub mod crypto;
+pub mod file_store;
 pub mod kes;
 pub mod monero;
 pub mod payment_channel;

--- a/libgrease/src/monero/dummy_impl.rs
+++ b/libgrease/src/monero/dummy_impl.rs
@@ -1,5 +1,7 @@
 use crate::monero::MultiSigWallet;
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DummyWallet;
 
 impl MultiSigWallet for DummyWallet {

--- a/libgrease/src/monero/traits.rs
+++ b/libgrease/src/monero/traits.rs
@@ -1,3 +1,6 @@
-pub trait MultiSigWallet {
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub trait MultiSigWallet: Serialize + DeserializeOwned {
     fn create(num_signers: usize, threshold: usize) -> Self;
 }

--- a/libgrease/src/payment_channel/dummy_impl.rs
+++ b/libgrease/src/payment_channel/dummy_impl.rs
@@ -2,7 +2,9 @@ use crate::channel_id::ChannelId;
 use crate::payment_channel::traits::ActivePaymentChannel;
 use crate::payment_channel::{ChannelRole, ClosedPaymentChannel, UpdateError};
 use crate::state_machine::Balances;
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DummyActiveChannel {
     channel_id: ChannelId,
     role: ChannelRole,
@@ -61,6 +63,7 @@ pub struct DummyUpdateInfo {
     pub new_balance: Balances,
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct DummyClosedChannel {
     channel_id: ChannelId,
     role: ChannelRole,

--- a/libgrease/src/payment_channel/traits.rs
+++ b/libgrease/src/payment_channel/traits.rs
@@ -2,6 +2,7 @@ use crate::amount::MoneroAmount;
 use crate::channel_id::ChannelId;
 use crate::payment_channel::{ChannelRole, UpdateError};
 use crate::state_machine::Balances;
+use serde::{Deserialize, Serialize};
 
 pub trait ChannelPayment: Sized {
     fn get_amount(&self) -> MoneroAmount;
@@ -10,7 +11,7 @@ pub trait ChannelPayment: Sized {
     fn get_sender_signature(&self) -> String;
 }
 
-pub trait ActivePaymentChannel {
+pub trait ActivePaymentChannel: Serialize + for<'d> Deserialize<'d> {
     type UpdateInfo;
     type Finalized: ClosedPaymentChannel;
 
@@ -29,7 +30,7 @@ pub trait ActivePaymentChannel {
     fn finalize(self) -> Self::Finalized;
 }
 
-pub trait ClosedPaymentChannel {
+pub trait ClosedPaymentChannel: Serialize + for<'d> Deserialize<'d> {
     fn channel_id(&self) -> &ChannelId;
     fn role(&self) -> ChannelRole;
     fn final_balance(&self) -> Balances;

--- a/libgrease/src/state_machine/closed_channel.rs
+++ b/libgrease/src/state_machine/closed_channel.rs
@@ -5,7 +5,10 @@ use crate::payment_channel::{ChannelRole, ClosedPaymentChannel};
 use crate::state_machine::disputing_channel::DisputeResult;
 use crate::state_machine::new_channel::{RejectNewChannelReason, TimeoutReason};
 use crate::state_machine::traits::ChannelState;
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>")]
 pub struct ClosedChannelState<P, W, C>
 where
     P: PublicKey,
@@ -17,6 +20,8 @@ where
     channel: CloseType<C>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>")]
 enum CloseType<C: ClosedPaymentChannel> {
     Channel(C),
     NoChannel { channel_id: ChannelId, channel_role: ChannelRole },
@@ -77,7 +82,8 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
 pub enum ChannelClosedReason<P: PublicKey> {
     /// The channel was closed normally
     Normal,

--- a/libgrease/src/state_machine/closed_channel.rs
+++ b/libgrease/src/state_machine/closed_channel.rs
@@ -8,7 +8,7 @@ use crate::state_machine::traits::ChannelState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct ClosedChannelState<P, W, C>
 where
     P: PublicKey,
@@ -21,7 +21,7 @@ where
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>"))]
 enum CloseType<C: ClosedPaymentChannel> {
     Channel(C),
     NoChannel { channel_id: ChannelId, channel_role: ChannelRole },
@@ -83,7 +83,7 @@ where
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
 pub enum ChannelClosedReason<P: PublicKey> {
     /// The channel was closed normally
     Normal,

--- a/libgrease/src/state_machine/closing_channel.rs
+++ b/libgrease/src/state_machine/closing_channel.rs
@@ -5,7 +5,10 @@ use crate::monero::MultiSigWallet;
 use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
 use crate::state_machine::traits::ChannelState;
 use crate::state_machine::EstablishedChannelState;
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
 pub struct ClosingChannelState<P, C, W, KES>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/closing_channel.rs
+++ b/libgrease/src/state_machine/closing_channel.rs
@@ -8,7 +8,7 @@ use crate::state_machine::EstablishedChannelState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct ClosingChannelState<P, C, W, KES>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/disputing_channel.rs
+++ b/libgrease/src/state_machine/disputing_channel.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct DisputingChannelState<P, C, W, KES>
 where
     P: PublicKey,
@@ -122,7 +122,7 @@ impl<P: PublicKey> Debug for DisputeWonInfo<P> {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
 pub enum DisputeResult<P: PublicKey> {
     UncontestedForceClose,
     DisputeLost(DisputeLostInfo),

--- a/libgrease/src/state_machine/disputing_channel.rs
+++ b/libgrease/src/state_machine/disputing_channel.rs
@@ -5,8 +5,11 @@ use crate::monero::MultiSigWallet;
 use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
 use crate::state_machine::traits::ChannelState;
 use crate::state_machine::{ClosingChannelState, EstablishedChannelState};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
 pub struct DisputingChannelState<P, C, W, KES>
 where
     P: PublicKey,
@@ -22,6 +25,7 @@ where
     pub(crate) kes: KES,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DisputeOrigin {
     /// You have  initiated a force close.
     ForceCloseTriggered,
@@ -100,12 +104,12 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DisputeLostInfo {
     pub(crate) reason: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DisputeWonInfo<P: PublicKey> {
     pub(crate) reason: String,
     pub(crate) peer_spend_key: P::SecretKey,
@@ -117,7 +121,8 @@ impl<P: PublicKey> Debug for DisputeWonInfo<P> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
 pub enum DisputeResult<P: PublicKey> {
     UncontestedForceClose,
     DisputeLost(DisputeLostInfo),

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -9,7 +9,7 @@ use crate::state_machine::traits::ChannelState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
 pub struct EstablishingChannelState<P: PublicKey> {
     pub role: ChannelRole,
     pub(crate) secret_key: P::SecretKey,

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -8,6 +8,8 @@ use crate::payment_channel::ChannelRole;
 use crate::state_machine::traits::ChannelState;
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
 pub struct EstablishingChannelState<P: PublicKey> {
     pub role: ChannelRole,
     pub(crate) secret_key: P::SecretKey,

--- a/libgrease/src/state_machine/lifecycle.rs
+++ b/libgrease/src/state_machine/lifecycle.rs
@@ -87,7 +87,7 @@ impl Display for LifecycleStage {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
 pub enum ChannelLifeCycle<P, C, W, KES>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/mod.rs
+++ b/libgrease/src/state_machine/mod.rs
@@ -7,10 +7,10 @@ mod closing_channel;
 mod disputing_channel;
 pub mod error;
 mod establishing_channel;
-mod lifecycle;
+pub mod lifecycle;
 mod new_channel;
 mod open_channel;
-mod traits;
+pub mod traits;
 
 pub use closed_channel::{ChannelClosedReason, ClosedChannelState};
 pub use closing_channel::{ClosingChannelState, StartCloseInfo, SuccessfulCloseInfo};

--- a/libgrease/src/state_machine/new_channel.rs
+++ b/libgrease/src/state_machine/new_channel.rs
@@ -7,6 +7,7 @@ use crate::state_machine::establishing_channel::Balances;
 use crate::state_machine::traits::ChannelState;
 use crate::state_machine::LifecycleStage;
 use digest::Digest;
+use serde::{Deserialize, Serialize};
 
 /// Holds all information that needs to be collected before the merchant and client can begin the channel
 /// establishment protocol. At the successful conclusion of this phase, we can emit an `OnNewChannelInfo` event with
@@ -27,7 +28,8 @@ pub struct NewChannelBuilder<P: PublicKey> {
     customer_amount: Option<MoneroAmount>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct RejectNewChannelReason(String);
 
 impl RejectNewChannelReason {
@@ -129,8 +131,12 @@ impl<P: PublicKey> NewChannelBuilder<P> {
 }
 
 /// The internal state of the channel in the "new" phase.
-#[derive(Clone)]
-pub struct NewChannelState<P: PublicKey> {
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+pub struct NewChannelState<P>
+where
+    P: PublicKey,
+{
     /// My role, whether customer or merchant
     pub role: ChannelRole,
     /// My secret key for the 2-of-2 multisig wallet
@@ -203,7 +209,7 @@ pub struct ProposedChannelInfo<P: PublicKey> {
     pub channel_id: ChannelId,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimeoutReason {
     /// The reason for the timeout
     reason: String,

--- a/libgrease/src/state_machine/new_channel.rs
+++ b/libgrease/src/state_machine/new_channel.rs
@@ -132,7 +132,7 @@ impl<P: PublicKey> NewChannelBuilder<P> {
 
 /// The internal state of the channel in the "new" phase.
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(bound = "P: PublicKey  + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
 pub struct NewChannelState<P>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -6,6 +6,7 @@ use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
 use crate::state_machine::establishing_channel::ChannelEstablishedInfo;
 use crate::state_machine::traits::ChannelState;
 use log::debug;
+use serde::{Deserialize, Serialize};
 
 pub struct ChannelUpdateInfo<C>
 where
@@ -24,6 +25,8 @@ where
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
 pub struct EstablishedChannelState<P, C, W, KES>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -26,7 +26,7 @@ where
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(bound = "C: ActivePaymentChannel + for<'d> Deserialize<'d>")]
+#[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct EstablishedChannelState<P, C, W, KES>
 where
     P: PublicKey,

--- a/libgrease/src/state_machine/traits.rs
+++ b/libgrease/src/state_machine/traits.rs
@@ -1,5 +1,9 @@
 use crate::channel_id::ChannelId;
-use crate::payment_channel::ChannelRole;
+use crate::crypto::traits::PublicKey;
+use crate::kes::KeyEscrowService;
+use crate::monero::MultiSigWallet;
+use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
+use crate::state_machine::ChannelLifeCycle;
 
 /// Common functionality for all channel states in the channel lifecycle
 pub trait ChannelState {
@@ -14,4 +18,15 @@ pub trait ChannelState {
 
     /// The role of the channel, which can be either customer or merchant.
     fn role(&self) -> ChannelRole;
+}
+
+pub trait StateStore<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    fn write_channel(&mut self, state: &ChannelLifeCycle<P, C, W, KES>) -> Result<(), anyhow::Error>;
+    fn load_channel(&self, channel_name: &str) -> Result<ChannelLifeCycle<P, C, W, KES>, anyhow::Error>;
 }


### PR DESCRIPTION
Adds the `StateStore` trait which lets us create various implementations for persisting state.

`FileStore` is a simple file-based implementation that stores the channel state in a file with the same name.

Making `ChannelLifeCycle` derive `Deserialize`required touching a lot of files, but it's the most robust solution, I feel.

A nice test that stores and loads the state for every transition on the happy path illustrates that this works.

Be aware: Secret keys are stored in plain text in the current implementation. We'll want to come up with a more secure implementation in future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a file-based persistent store for payment channel states, enabling saving and loading of channel lifecycle data.
  - Added a generic trait for state storage, supporting flexible persistence backends.
- **Improvements**
  - Enabled serialization and deserialization for key payment channel, wallet, and key escrow types, allowing channel state persistence and interchange.
  - Enhanced visibility of modules and helper functions for improved extensibility.
  - Updated channel identifier formatting for improved readability.
- **Chores**
  - Updated dependencies and ignore rules to streamline development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->