### PR TITLE
feat: channel proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,16 +305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee55e9ca33be1f257d8356cfb29b10b1c8f86dc38cf1344ca01525464356cd0c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1089,7 @@ name = "grease-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "clap",
  "dialoguer",
  "env_logger",
@@ -1110,6 +1101,7 @@ dependencies = [
  "prettytable-rs",
  "qrcode",
  "rand 0.9.1",
+ "ron",
  "serde",
  "serde_json",
  "serde_yml",
@@ -1121,6 +1113,7 @@ dependencies = [
 name = "grease-p2p"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "env_logger",
  "futures",
  "hex",
@@ -1667,7 +1660,6 @@ name = "libgrease"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "blake",
  "blake2",
  "curve25519-dalek",
  "digest",
@@ -1677,7 +1669,6 @@ dependencies = [
  "rand 0.9.1",
  "ron",
  "serde",
- "serde_yml",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ grease-p2p = { version = "0.1.0", path = "./p2p" }
 libgrease = { version = "0.1.0", path = "./libgrease" }
 
 anyhow = { version = "1.0.96" }
+blake2 = {  version = "0.10.6"}
 clap = { version = "4.5.31" }
 env_logger = { version = "0.11.6" }
 futures = { version = "0.3" }

--- a/grease_cli/Cargo.toml
+++ b/grease_cli/Cargo.toml
@@ -8,6 +8,7 @@ grease-p2p = { workspace = true }
 libgrease = { workspace = true }
 
 anyhow = { workspace = true }
+blake2 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "unicode"] }
 dialoguer = { version = "0.11.0", default-features = false, features = ["completion", "fuzzy-select", "history", "editor"] }
 env_logger = { workspace = true }
@@ -19,6 +20,7 @@ rand = { workspace = true }
 qrcode = {  version = "0.14.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+ron = { workspace = true }
 serde_yml = {  workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/grease_cli/src/channel_management.rs
+++ b/grease_cli/src/channel_management.rs
@@ -1,49 +1,16 @@
-use grease_p2p::{ContactInfo, ConversationIdentity};
-use libgrease::crypto::traits::PublicKey;
-use libgrease::kes::KeyEscrowService;
-use libgrease::monero::MultiSigWallet;
-use libgrease::payment_channel::ActivePaymentChannel;
-use libgrease::state_machine::{ChannelLifeCycle, ChannelSeedInfo};
-use serde::{Deserialize, Serialize};
+use crate::id_management::MoneroKeyManager;
+use grease_p2p::{DummyDelegate, NetworkServer, OutOfBandMerchantInfo, PaymentChannel, PaymentChannels};
+use libgrease::crypto::keys::Curve25519PublicKey;
+use libgrease::kes::dummy_impl::DummyKes;
+use libgrease::monero::dummy_impl::DummyWallet;
+use libgrease::payment_channel::dummy_impl::DummyActiveChannel;
+use libgrease::state_machine::{ChannelLifeCycle, NewChannelBuilder, NewChannelState};
 
-#[derive(Serialize, Deserialize)]
-#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
-pub struct OutOfBandMerchantInfo<P>
-where
-    P: PublicKey,
-{
-    pub contact: ContactInfo,
-    pub seed: ChannelSeedInfo<P>,
-}
-
-impl<P> OutOfBandMerchantInfo<P>
-where
-    P: PublicKey,
-{
-    /// Creates a new `OutOfBandMerchantInfo` with the given contact and channel seed information.
-    pub fn new(contact: ContactInfo, seed: ChannelSeedInfo<P>) -> Self {
-        OutOfBandMerchantInfo { contact, seed }
-    }
-}
-
-/// A payments channel
-///
-/// A payment channel comprises
-/// - the details of the peer (i.e. a way to connect to them over the internet)
-/// - the current state of the Monero payment channel
-///
-/// Again, the word channel is overloaded
-#[derive(Serialize, Deserialize)]
-#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
-pub struct PaymentChannel<P, C, W, KES>
-where
-    P: PublicKey,
-    C: ActivePaymentChannel,
-    W: MultiSigWallet,
-    KES: KeyEscrowService,
-{
-    pub identity: ConversationIdentity,
-    pub peer_info: ContactInfo,
-    pub seed_info: ChannelSeedInfo<P>,
-    pub state: ChannelLifeCycle<P, C, W, KES>,
-}
+pub type MoneroPaymentChannel = PaymentChannel<Curve25519PublicKey, DummyActiveChannel, DummyWallet, DummyKes>;
+pub type MoneroPaymentChannels = PaymentChannels<Curve25519PublicKey, DummyActiveChannel, DummyWallet, DummyKes>;
+pub type MoneroOutOfBandMerchantInfo = OutOfBandMerchantInfo<Curve25519PublicKey>;
+pub type MoneroLifeCycle = ChannelLifeCycle<Curve25519PublicKey, DummyActiveChannel, DummyWallet, DummyKes>;
+pub type MoneroNewState = NewChannelState<Curve25519PublicKey>;
+pub type MoneroChannelBuilder = NewChannelBuilder<Curve25519PublicKey>;
+pub type MoneroNetworkServer =
+    NetworkServer<Curve25519PublicKey, DummyActiveChannel, DummyWallet, DummyKes, DummyDelegate, MoneroKeyManager>;

--- a/grease_cli/src/interactive/formatting.rs
+++ b/grease_cli/src/interactive/formatting.rs
@@ -1,9 +1,6 @@
-use std::fmt::Write;
-
-use anyhow::Result;
 use prettytable::{
     format::{LinePosition, LineSeparator, TableFormat},
-    row, Cell, Row, Table,
+    Table,
 };
 use qrcode::{render::unicode, QrCode};
 

--- a/grease_cli/src/interactive/menus.rs
+++ b/grease_cli/src/interactive/menus.rs
@@ -14,14 +14,13 @@ pub mod commands {
     pub const FORCE_CLOSE_CHANNEL: &str = "Force Close the channel";
     pub const LIST_CHANNELS: &str = "List channels";
     pub const LIST_IDENTITIES: &str = "List identities";
-    pub const LOGOUT: &str = "Logout";
     pub const NAV_BACK: &str = "Back";
     pub const NAV_TO_CUSTOMER_MENU: &str = "For Customers";
     pub const NAV_TO_IDENTITY_MENU: &str = "Manage Identities";
     pub const NAV_TO_MERCHANT_MENU: &str = "For Merchants";
     pub const PAYMENT_REQUEST: &str = "Request payment";
     pub const PAYMENT_SEND: &str = "Send payment";
-    pub const PROPOSE_CHANNEL: &str = "Create New channel";
+    pub const PROPOSE_CHANNEL: &str = "Initiate new channel";
     pub const REMOVE_IDENTITY: &str = "Remove identity";
     pub const SHARE_MERCHANT_INFO: &str = "Display new channel QR code";
 }
@@ -30,14 +29,13 @@ pub use commands::*;
 
 pub const TOP_MENU: [&str; 4] = [NAV_TO_CUSTOMER_MENU, NAV_TO_MERCHANT_MENU, NAV_TO_IDENTITY_MENU, EXIT];
 
-pub const IDENTITY_MENU: [&str; 8] = [
+pub const IDENTITY_MENU: [&str; 7] = [
     LIST_IDENTITIES,
     ADD_IDENTITY,
     REMOVE_IDENTITY,
     NAV_TO_CUSTOMER_MENU,
     NAV_TO_MERCHANT_MENU,
     NAV_BACK,
-    LOGOUT,
     EXIT,
 ];
 

--- a/grease_cli/src/interactive/mod.rs
+++ b/grease_cli/src/interactive/mod.rs
@@ -162,6 +162,8 @@ impl InteractiveApp {
                 let channel = self.create_channel(secret, final_proposal, proposal)?;
                 let name = channel.name();
                 self.server.add_channel(channel).await;
+                self.save_channels().await?;
+                info!("Channels saved.");
                 self.current_channel = Some(name.clone());
                 Ok(format!("Channel proposal accepted! Channel ID: {name}"))
             }

--- a/grease_cli/src/lib.rs
+++ b/grease_cli/src/lib.rs
@@ -3,4 +3,5 @@ pub mod config;
 pub mod error;
 pub mod id_management;
 pub mod interactive;
+pub mod other_commands;
 pub mod server;

--- a/grease_cli/src/main.rs
+++ b/grease_cli/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use grease_cli::config::{CliCommand, CliOptions, GlobalOptions};
 use grease_cli::id_management::exec_id_command;
-use grease_cli::server::start_server;
+use grease_cli::other_commands::print_random_keypair;
+use grease_cli::server::start;
+use libgrease::crypto::keys::Curve25519PublicKey;
 
 #[tokio::main]
 /// Entry point for the CLI application.
@@ -20,7 +22,8 @@ async fn main() {
 
     let result = match options.command {
         CliCommand::Id(id_command) => exec_id_command(id_command, config),
-        CliCommand::Serve(serve_command) => start_server(serve_command, config).await,
+        CliCommand::Serve => start::<Curve25519PublicKey>(config).await,
+        CliCommand::Keypair => print_random_keypair(),
     };
 
     match result {

--- a/grease_cli/src/main.rs
+++ b/grease_cli/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     let result = match options.command {
         CliCommand::Id(id_command) => exec_id_command(id_command, config),
-        CliCommand::Serve => start::<Curve25519PublicKey>(config).await,
+        CliCommand::Serve => start(config).await,
         CliCommand::Keypair => print_random_keypair(),
     };
 

--- a/grease_cli/src/other_commands.rs
+++ b/grease_cli/src/other_commands.rs
@@ -1,0 +1,9 @@
+use libgrease::crypto::keys::Curve25519PublicKey;
+use libgrease::crypto::traits::PublicKey;
+
+pub fn print_random_keypair() -> Result<(), anyhow::Error> {
+    let (secret, public) = Curve25519PublicKey::keypair(&mut rand::rng());
+    println!("Private Key: {}", secret.as_hex());
+    println!("Public Key: {}", public.as_hex());
+    Ok(())
+}

--- a/grease_cli/src/server.rs
+++ b/grease_cli/src/server.rs
@@ -26,7 +26,7 @@ async fn run_interactive(global_options: GlobalOptions) {
         Ok(app) => app,
         Err(err) => {
             eprintln!("** Error ** \n {err}");
-            std::process::exit(1);
+            return;
         }
     };
     let result = app.run().await;

--- a/grease_cli/src/server.rs
+++ b/grease_cli/src/server.rs
@@ -6,7 +6,7 @@ use log::*;
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 /// Starts the peer-to-peer payment channel server and runs the interactive application.
-pub async fn start<P: PublicKey + 'static>(config: GlobalOptions) -> Result<(), anyhow::Error> {
+pub async fn start(config: GlobalOptions) -> Result<(), anyhow::Error> {
     info!("Starting interactive server");
     run_interactive(config).await;
     info!("Server has shut down.");

--- a/grease_cli/src/server.rs
+++ b/grease_cli/src/server.rs
@@ -5,15 +5,7 @@ use log::*;
 
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
-/// Starts the peer-to-peer payment channel server or runs the interactive application.
-///
-/// If the `quiet` flag is set in the server command, initializes the server with the specified identity and  
-/// configuration, establishes a network connection, listens for incoming peer requests, and handles them asynchronously.
-/// Otherwise, launches the interactive command-line application.
-///
-/// # Returns
-///
-/// Returns `Ok(())` if the server or interactive application completes successfully, or an error if initialization or network operations fail.
+/// Starts the peer-to-peer payment channel server and runs the interactive application.
 pub async fn start<P: PublicKey + 'static>(config: GlobalOptions) -> Result<(), anyhow::Error> {
     info!("Starting interactive server");
     run_interactive(config).await;

--- a/grease_cli/src/server.rs
+++ b/grease_cli/src/server.rs
@@ -1,93 +1,40 @@
-use crate::config::{GlobalOptions, ServerCommand};
-use crate::id_management::{assign_identity, default_config_path};
+use crate::config::GlobalOptions;
 use crate::interactive::InteractiveApp;
-use futures::StreamExt;
-use grease_p2p::errors::PeerConnectionError;
-use grease_p2p::message_types::{AckChannelProposal, NewChannelProposal};
-use grease_p2p::{new_connection, Client, GreaseRequest, GreaseResponse, PeerConnectionEvent};
-use libp2p::request_response::ResponseChannel;
-use log::{debug, error, info, trace};
+use libgrease::crypto::traits::PublicKey;
+use log::*;
 
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 /// Starts the peer-to-peer payment channel server or runs the interactive application.
 ///
-/// If the `quiet` flag is set in the server command, initializes the server with the specified identity and configuration, establishes a network connection, listens for incoming peer requests, and handles them asynchronously. Otherwise, launches the interactive command-line application.
+/// If the `quiet` flag is set in the server command, initializes the server with the specified identity and  
+/// configuration, establishes a network connection, listens for incoming peer requests, and handles them asynchronously.
+/// Otherwise, launches the interactive command-line application.
 ///
 /// # Returns
 ///
 /// Returns `Ok(())` if the server or interactive application completes successfully, or an error if initialization or network operations fail.
-pub async fn start_server(cmd: ServerCommand, config: GlobalOptions) -> Result<(), anyhow::Error> {
-    info!("Starting server");
-    if cmd.quiet {
-        let path = config.identities_file.unwrap_or_else(default_config_path);
-        let identity = assign_identity(path, config.preferred_identity.as_ref())?;
-        let (mut network_client, mut network_events, network_event_loop) =
-            new_connection(identity.take_keypair()).await?;
-        // Spawn the network task for it to run in the background.
-        let handle = tokio::spawn(network_event_loop.run());
-        network_client.start_listening(cmd.listen_address).await?;
-        while let Some(ev) = network_events.next().await {
-            trace!("Event received.");
-            match ev {
-                PeerConnectionEvent::InboundRequest { request, channel } => {
-                    debug!("Inbound request received: {request:?}");
-                    let client = network_client.clone();
-                    tokio::spawn(async move {
-                        handle_incoming_grease_request(request, client, channel).await;
-                    });
-                }
-            }
-        }
-        handle.await?;
-        info!("Server has shut down.");
-    } else {
-        // If the user has not specified a command, run the interactive app.
-        run_interactive(config).await;
-    }
+pub async fn start<P: PublicKey + 'static>(config: GlobalOptions) -> Result<(), anyhow::Error> {
+    info!("Starting interactive server");
+    run_interactive(config).await;
+    info!("Server has shut down.");
     Ok(())
 }
 
-/// Business logic handling for payment channel requests.
-///
-/// This function is called by the network event loop when a new inbound request is received.
-/// It takes the request, performs the relevant work, and then calls the appropriate method on the network client
-/// to respond.
-pub async fn handle_incoming_grease_request(
-    request: GreaseRequest,
-    client: Client,
-    channel: ResponseChannel<GreaseResponse>,
-) {
-    let result = match request {
-        GreaseRequest::ProposeNewChannel(data) => handle_open_channel_request(data, client, channel).await,
-        GreaseRequest::SendMoney => todo!("SendMoney"),
-        GreaseRequest::RequestMoney => todo!("RequestMoney"),
-        GreaseRequest::CloseChannel => todo!("CloseChannel"),
-    };
-    if let Err(err) = result {
-        error!("Error handling request: {err}");
-    }
-}
-
-/// Handle an incoming request to open a payment channel.
-pub async fn handle_open_channel_request(
-    data: NewChannelProposal,
-    mut client: Client,
-    channel: ResponseChannel<GreaseResponse>,
-) -> Result<(), PeerConnectionError> {
-    // Perform the necessary work to open a channel.
-    // For now, we'll just return a successful response.
-    let success = AckChannelProposal { data };
-    client.send_channel_proposal_response(Ok(success), channel).await
-}
-
 async fn run_interactive(global_options: GlobalOptions) {
-    println!(
-        "No command given. If this was unintended, enter `CTRL-C` to exit and run `{APP_NAME} --help` to see a full \
-         list of commands."
-    );
-    let mut app = InteractiveApp::new(global_options);
-    match app.run().await {
+    let mut app = match InteractiveApp::new(global_options) {
+        Ok(app) => app,
+        Err(err) => {
+            eprintln!("** Error ** \n {err}");
+            std::process::exit(1);
+        }
+    };
+    let result = app.run().await;
+    match app.save_channels().await {
+        Ok(_) => info!("Channels saved."),
+        Err(e) => error!("Error saving channels: {}", e),
+    }
+    match result {
         Ok(_) => println!("Bye!"),
         Err(e) => error!("Session ended with error: {}", e),
     }

--- a/libgrease/Cargo.toml
+++ b/libgrease/Cargo.toml
@@ -11,7 +11,7 @@ test_features = ["dummy_channel"]
 
 [dependencies]
 anyhow = { workspace = true }
-blake = "2.0.2"
+blake2 = { workspace = true }
 curve25519-dalek = { version = "4.1.3", features = ["digest"] }
 digest = "0.10.7"
 hex = "0.4.3"
@@ -20,11 +20,9 @@ thiserror = "2.0.12"
 log = "0.4.27"
 ron = {  workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
-serde_yml = {  workspace = true }
 
 
 [dev-dependencies]
-blake2 = "0.10.6"
 env_logger = "0.11.8"
 
 [profile.test]

--- a/libgrease/src/amount.rs
+++ b/libgrease/src/amount.rs
@@ -69,7 +69,7 @@ impl MoneroAmount {
 
 impl PartialOrd for MoneroAmount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.amount.partial_cmp(&other.amount)
+        Some(self.amount.cmp(&other.amount))
     }
 }
 

--- a/libgrease/src/channel_id.rs
+++ b/libgrease/src/channel_id.rs
@@ -29,8 +29,8 @@ impl ChannelId {
         hasher.update(b"ChannelId");
         hasher.update(&merchant_id);
         hasher.update(&customer_id);
-        hasher.update(&amount_mer);
-        hasher.update(&amount_cust);
+        hasher.update(amount_mer);
+        hasher.update(amount_cust);
         hasher.update(&salt);
         let hashed_id = hasher.finalize().to_vec();
         ChannelId { merchant_id, customer_id, initial_balance, salt, hashed_id }

--- a/libgrease/src/crypto/cas.rs
+++ b/libgrease/src/crypto/cas.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Properties
 //! - **Sequential Dependence**: Each pre-signature \(\hat{\sigma}_i\) depends on its predecessor \
-//! (\hat{\sigma}_{i-1}\).
+//!   (\hat{\sigma}_{i-1}\).
 //! - **Forward Security**: Compromising \(y_i\) does not expose earlier secrets \(y_0, \dots, y_{i-1}\).
 //! - **Batch Verification**: Multiple pre-signatures can be verified efficiently using VCOF proofs.
 
@@ -160,7 +160,7 @@ pub trait ConsecutiveAdaptorSignature {
         let (r, pub_r) = self.generate_keypair();
         let r_sign = pub_r.as_point() + statement.as_public_key().as_point();
         let r_sign = Curve25519PublicKey::from(r_sign);
-        let public_key = pubkey.cloned().unwrap_or_else(|| Curve25519PublicKey::from_secret(&sk));
+        let public_key = pubkey.cloned().unwrap_or_else(|| Curve25519PublicKey::from_secret(sk));
         let challenge = self.hash_to_scalar(message, &r_sign, &public_key);
         // Schnorr signature scheme for partial signature
         let s = r.as_scalar() + challenge * sk.as_scalar();
@@ -182,7 +182,7 @@ pub trait ConsecutiveAdaptorSignature {
         let r_pre = &pre_sig.s * ED25519_BASEPOINT_TABLE - pre_sig.challenge * pubkey.as_point();
         let r_sign = r_pre + statement.as_public_key().as_point();
         let r_sign = Curve25519PublicKey::from(r_sign);
-        let challenge = self.hash_to_scalar(message, &r_sign, &pubkey);
+        let challenge = self.hash_to_scalar(message, &r_sign, pubkey);
         pre_sig.challenge == challenge
     }
 
@@ -197,7 +197,7 @@ pub trait ConsecutiveAdaptorSignature {
     /// Converts pre-signature to full signature using the given witness/secret
     fn adapt_pre_signature(&self, pre_sig: &PreSignature, witness: &Self::W) -> Signature {
         let s = pre_sig.s + witness.as_scalar();
-        let challenge = pre_sig.challenge.clone();
+        let challenge = pre_sig.challenge;
         Signature { s, challenge }
     }
 

--- a/libgrease/src/crypto/clras.rs
+++ b/libgrease/src/crypto/clras.rs
@@ -73,7 +73,7 @@ pub trait Clras2P {
             return Err(Clras2PError::invalid_pre_signature("The peer pre-signature is invalid"));
         }
         let s = pre_signature.s + peer_pre_signature.s;
-        Ok(Signature { challenge: pre_signature.challenge.clone(), s })
+        Ok(Signature { challenge: pre_signature.challenge, s })
     }
 
     fn pre_signature_verify<B: AsRef<[u8]>>(

--- a/libgrease/src/crypto/hashes.rs
+++ b/libgrease/src/crypto/hashes.rs
@@ -1,5 +1,6 @@
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::{EdwardsPoint, Scalar};
+use digest::Digest;
 
 pub trait HashToScalar: Default {
     type Scalar;
@@ -17,10 +18,10 @@ pub struct Blake512;
 impl HashToScalar for Blake512 {
     type Scalar = Scalar;
     fn hash_to_scalar<B: AsRef<[u8]>>(&mut self, input: B) -> Self::Scalar {
-        let mut hasher = blake::Blake::new(512).expect("Should be able to create Blake instance");
+        let mut hasher = blake2::Blake2b512::new();
         hasher.update(input.as_ref());
         let mut result = [0u8; 64];
-        hasher.finalise(&mut result);
+        result.copy_from_slice(hasher.finalize().as_slice());
         Scalar::from_bytes_mod_order_wide(&result)
     }
 }
@@ -28,10 +29,10 @@ impl HashToScalar for Blake512 {
 impl HashToPoint for Blake512 {
     type Point = EdwardsPoint;
     fn hash_to_point<B: AsRef<[u8]>>(&mut self, input: B) -> Self::Point {
-        let mut hasher = blake::Blake::new(512).expect("Should be able to create Blake instance");
+        let mut hasher = blake2::Blake2b512::new();
         hasher.update(input.as_ref());
         let mut result = [0u8; 64];
-        hasher.finalise(&mut result);
+        result.copy_from_slice(hasher.finalize().as_slice());
         let scalar = Scalar::from_bytes_mod_order_wide(&result);
         &scalar * ED25519_BASEPOINT_TABLE
     }

--- a/libgrease/src/crypto/traits.rs
+++ b/libgrease/src/crypto/traits.rs
@@ -1,9 +1,9 @@
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-pub trait SecretKey: Clone + Serialize + for<'de> Deserialize<'de> {}
+pub trait SecretKey: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> {}
 
-pub trait PublicKey: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> {
+pub trait PublicKey: Clone + PartialEq + Eq + Send + Sync + Serialize + for<'de> Deserialize<'de> {
     type SecretKey: SecretKey;
 
     fn keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (Self::SecretKey, Self);

--- a/libgrease/src/kes/traits.rs
+++ b/libgrease/src/kes/traits.rs
@@ -1,3 +1,3 @@
 use serde::{Deserialize, Serialize};
 
-pub trait KeyEscrowService: Serialize + for<'de> Deserialize<'de> {}
+pub trait KeyEscrowService: Serialize + for<'de> Deserialize<'de> + Send + Sync {}

--- a/libgrease/src/monero/traits.rs
+++ b/libgrease/src/monero/traits.rs
@@ -1,6 +1,5 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-pub trait MultiSigWallet: Serialize + DeserializeOwned {
+pub trait MultiSigWallet: Serialize + for<'de> Deserialize<'de> + Send + Sync {
     fn create(num_signers: usize, threshold: usize) -> Self;
 }

--- a/libgrease/src/payment_channel/dummy_impl.rs
+++ b/libgrease/src/payment_channel/dummy_impl.rs
@@ -63,7 +63,7 @@ pub struct DummyUpdateInfo {
     pub new_balance: Balances,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DummyClosedChannel {
     channel_id: ChannelId,
     role: ChannelRole,

--- a/libgrease/src/payment_channel/mod.rs
+++ b/libgrease/src/payment_channel/mod.rs
@@ -15,3 +15,12 @@ pub enum ChannelRole {
     Merchant,
     Customer,
 }
+
+impl ChannelRole {
+    pub fn other(&self) -> Self {
+        match self {
+            ChannelRole::Merchant => ChannelRole::Customer,
+            ChannelRole::Customer => ChannelRole::Merchant,
+        }
+    }
+}

--- a/libgrease/src/payment_channel/traits.rs
+++ b/libgrease/src/payment_channel/traits.rs
@@ -11,9 +11,9 @@ pub trait ChannelPayment: Sized {
     fn get_sender_signature(&self) -> String;
 }
 
-pub trait ActivePaymentChannel: Serialize + for<'d> Deserialize<'d> {
+pub trait ActivePaymentChannel: Serialize + for<'d> Deserialize<'d> + Send + Sync {
     type UpdateInfo;
-    type Finalized: ClosedPaymentChannel;
+    type Finalized: ClosedPaymentChannel + Send + Sync;
 
     fn role(&self) -> ChannelRole;
     fn channel_id(&self) -> &ChannelId;
@@ -30,7 +30,7 @@ pub trait ActivePaymentChannel: Serialize + for<'d> Deserialize<'d> {
     fn finalize(self) -> Self::Finalized;
 }
 
-pub trait ClosedPaymentChannel: Serialize + for<'d> Deserialize<'d> {
+pub trait ClosedPaymentChannel: Clone + Serialize + for<'d> Deserialize<'d> + Send {
     fn channel_id(&self) -> &ChannelId;
     fn role(&self) -> ChannelRole;
     fn final_balance(&self) -> Balances;

--- a/libgrease/src/state_machine/closed_channel.rs
+++ b/libgrease/src/state_machine/closed_channel.rs
@@ -7,7 +7,7 @@ use crate::state_machine::new_channel::{RejectNewChannelReason, TimeoutReason};
 use crate::state_machine::traits::ChannelState;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct ClosedChannelState<P, W, C>
 where
@@ -20,7 +20,7 @@ where
     channel: CloseType<C>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "C: ClosedPaymentChannel + for<'d> Deserialize<'d>"))]
 enum CloseType<C: ClosedPaymentChannel> {
     Channel(C),

--- a/libgrease/src/state_machine/closing_channel.rs
+++ b/libgrease/src/state_machine/closing_channel.rs
@@ -7,7 +7,7 @@ use crate::state_machine::traits::ChannelState;
 use crate::state_machine::EstablishedChannelState;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct ClosingChannelState<P, C, W, KES>
 where
@@ -48,7 +48,7 @@ where
     KES: KeyEscrowService,
 {
     fn channel_id(&self) -> &ChannelId {
-        &self.payment_channel.channel_id()
+        self.payment_channel.channel_id()
     }
 
     fn role(&self) -> ChannelRole {

--- a/libgrease/src/state_machine/disputing_channel.rs
+++ b/libgrease/src/state_machine/disputing_channel.rs
@@ -8,7 +8,7 @@ use crate::state_machine::{ClosingChannelState, EstablishedChannelState};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct DisputingChannelState<P, C, W, KES>
 where

--- a/libgrease/src/state_machine/mod.rs
+++ b/libgrease/src/state_machine/mod.rs
@@ -17,5 +17,5 @@ pub use closing_channel::{ClosingChannelState, StartCloseInfo, SuccessfulCloseIn
 pub use disputing_channel::{DisputeOrigin, DisputeResolvedInfo, DisputingChannelState, ForceCloseInfo};
 pub use establishing_channel::{Balances, EstablishingChannelState};
 pub use lifecycle::{ChannelLifeCycle, LifecycleStage};
-pub use new_channel::{ChannelSeedBuilder, ChannelSeedInfo, NewChannelBuilder};
+pub use new_channel::{ChannelSeedBuilder, ChannelSeedInfo, NewChannelBuilder, NewChannelState};
 pub use open_channel::EstablishedChannelState;

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -25,7 +25,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "C: ActivePaymentChannel + for<'d> Deserialize<'d>"))]
 pub struct EstablishedChannelState<P, C, W, KES>
 where
@@ -85,7 +85,7 @@ where
     KES: KeyEscrowService,
 {
     fn channel_id(&self) -> &ChannelId {
-        &self.payment_channel.channel_id()
+        self.payment_channel.channel_id()
     }
 
     fn role(&self) -> ChannelRole {

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_yml = {  workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+blake2 = "0.10.6"
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -1,10 +1,11 @@
 use crate::{GreaseRequest, GreaseResponse};
+use libgrease::crypto::traits::PublicKey;
 use libp2p::identify;
 use libp2p::request_response::json;
 use libp2p::swarm::NetworkBehaviour;
 
 #[derive(NetworkBehaviour)]
-pub struct ConnectionBehavior {
+pub struct ConnectionBehavior<P: PublicKey + Send + 'static> {
     pub(crate) identify: identify::Behaviour,
-    pub(crate) json: json::Behaviour<GreaseRequest, GreaseResponse>,
+    pub(crate) json: json::Behaviour<GreaseRequest<P>, GreaseResponse<P>>,
 }

--- a/p2p/src/delegate.rs
+++ b/p2p/src/delegate.rs
@@ -1,0 +1,40 @@
+use crate::message_types::NewChannelProposal;
+use libgrease::crypto::keys::{Curve25519PublicKey, KeyError};
+use libgrease::crypto::traits::PublicKey;
+use libgrease::kes::dummy_impl::DummyKes;
+use libgrease::kes::KeyEscrowService;
+use libgrease::monero::dummy_impl::DummyWallet;
+use libgrease::monero::MultiSigWallet;
+use libgrease::payment_channel::dummy_impl::DummyActiveChannel;
+use libgrease::payment_channel::ActivePaymentChannel;
+use libgrease::state_machine::error::InvalidProposal;
+use log::info;
+use serde::{Deserialize, Serialize};
+
+pub trait GreaseChannelDelegate<P, C, W, KES>: Clone + Send + Sync
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    fn verify_proposal(&self, data: &NewChannelProposal<P>) -> Result<(), InvalidProposal>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DummyDelegate;
+
+impl GreaseChannelDelegate<Curve25519PublicKey, DummyActiveChannel, DummyWallet, DummyKes> for DummyDelegate {
+    fn verify_proposal(&self, _data: &NewChannelProposal<Curve25519PublicKey>) -> Result<(), InvalidProposal> {
+        info!("Rubber stamping proposal");
+        Ok(())
+    }
+}
+
+pub trait KeyDelegate<P>: Clone + Send + Sync
+where
+    P: PublicKey,
+{
+    fn get_keypair(&self, index: u64) -> Result<(P::SecretKey, P), KeyError>;
+    fn validate_keypair(&self, secret: &P::SecretKey, public: &P) -> bool;
+}

--- a/p2p/src/errors.rs
+++ b/p2p/src/errors.rs
@@ -21,4 +21,18 @@ pub enum PeerConnectionError {
     EventLoopShuttingDown,
     #[error("Will never happen, but required for the error trait")]
     Infallible(#[from] Infallible),
+    #[error("The channel {0} does not exist.")]
+    ChannelNotFound(String),
+    #[error("An established channel cannot make a new proposal")]
+    NotANewChannel,
+}
+
+#[derive(Error, Debug)]
+pub enum PaymentChannelError {
+    #[error("Error loading channel. {0}")]
+    LoadingError(String),
+    #[error("I/O error. {0}")]
+    IOError(#[from] std::io::Error),
+    #[error("Error serializing channel. {0}")]
+    SerializationError(#[from] ron::Error),
 }

--- a/p2p/src/identity.rs
+++ b/p2p/src/identity.rs
@@ -1,5 +1,6 @@
 use libp2p::identity::Keypair;
 use libp2p::{Multiaddr, PeerId};
+use log::*;
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
@@ -43,7 +44,10 @@ impl ConversationIdentity {
     }
 
     pub fn dial_address(&self) -> Multiaddr {
-        self.address.clone().with_p2p(self.peer_id).unwrap_or_else(|e| e)
+        self.address.clone().with_p2p(self.peer_id).unwrap_or_else(|orig| {
+            warn!("Peer id and listen address don't match. Using original listen address, {orig}");
+            orig
+        })
     }
 
     pub fn keypair(&self) -> &Keypair {

--- a/p2p/src/key_manager.rs
+++ b/p2p/src/key_manager.rs
@@ -1,0 +1,21 @@
+use libgrease::crypto::traits::PublicKey;
+
+pub trait KeyManager: Clone {
+    type PublicKey: PublicKey;
+
+    /// Creates a new `KeyManager` from the given secret key, deriving its corresponding public key.
+    fn new(initial_key: <Self::PublicKey as PublicKey>::SecretKey) -> Self;
+
+    /// Deterministically generates a new keypair based on the initial secret key and a given index.
+    ///
+    /// # Parameters
+    /// - `index`: The index used to derive a unique keypair from the initial secret.
+    ///
+    /// # Returns
+    /// A tuple containing the derived secret key and its corresponding public key.
+    fn new_keypair(&self, index: u64) -> (<Self::PublicKey as PublicKey>::SecretKey, Self::PublicKey);
+
+    fn initial_public_key(&self) -> &Self::PublicKey;
+
+    fn validate_keypair(&self, secret: &<Self::PublicKey as PublicKey>::SecretKey, public: &Self::PublicKey) -> bool;
+}

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,11 +1,19 @@
 mod behaviour;
+mod delegate;
 pub mod errors;
 mod event_loop;
 mod identity;
+mod key_manager;
 pub mod message_types;
 mod network_client;
+mod payment_channel;
+mod server;
 
+pub use delegate::{DummyDelegate, GreaseChannelDelegate, KeyDelegate};
 pub use event_loop::EventLoop;
 pub use identity::{ContactInfo, ConversationIdentity, IdentityError};
+pub use key_manager::KeyManager;
 pub use message_types::{ClientCommand, GreaseRequest, GreaseResponse, PeerConnectionEvent};
-pub use network_client::{new_connection, Client, PeerConnection};
+pub use network_client::{new_network, Client, PeerConnection};
+pub use payment_channel::{OutOfBandMerchantInfo, PaymentChannel, PaymentChannels};
+pub use server::{NetworkServer, WritableState};

--- a/p2p/src/payment_channel.rs
+++ b/p2p/src/payment_channel.rs
@@ -1,0 +1,232 @@
+use crate::errors::PaymentChannelError;
+use crate::ContactInfo;
+use libgrease::crypto::traits::PublicKey;
+use libgrease::kes::KeyEscrowService;
+use libgrease::monero::MultiSigWallet;
+use libgrease::payment_channel::ActivePaymentChannel;
+use libgrease::state_machine::{ChannelLifeCycle, ChannelSeedInfo};
+use libp2p::{Multiaddr, PeerId};
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
+pub struct OutOfBandMerchantInfo<P>
+where
+    P: PublicKey,
+{
+    pub contact: ContactInfo,
+    pub seed: ChannelSeedInfo<P>,
+}
+
+impl<P> OutOfBandMerchantInfo<P>
+where
+    P: PublicKey,
+{
+    /// Creates a new `OutOfBandMerchantInfo` with the given contact and channel seed information.
+    pub fn new(contact: ContactInfo, seed: ChannelSeedInfo<P>) -> Self {
+        OutOfBandMerchantInfo { contact, seed }
+    }
+}
+
+/// A payments channel
+///
+/// A payment channel comprises
+/// - the details of the peer (i.e. a way to connect to them over the internet)
+/// - the current state of the Monero payment channel
+///
+/// Again, the word channel is overloaded
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(deserialize = "P: PublicKey  + for<'d> Deserialize<'d>"))]
+pub struct PaymentChannel<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    pub peer_info: ContactInfo,
+    pub state: ChannelLifeCycle<P, C, W, KES>,
+}
+
+impl<P, C, W, KES> PaymentChannel<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    /// Creates a new `PaymentChannel` with the given identity and peer information.
+    pub fn new(peer_info: ContactInfo, state: ChannelLifeCycle<P, C, W, KES>) -> Self {
+        PaymentChannel { peer_info, state }
+    }
+
+    pub fn try_load_from_file<PATH: AsRef<Path>>(path: PATH) -> Result<Self, PaymentChannelError> {
+        if path.as_ref().is_file() {
+            let file_name = path.as_ref().file_name().unwrap().to_string_lossy().to_string();
+            if file_name.ends_with(".ron") {
+                fs::read_to_string(path).map_err(|e| PaymentChannelError::LoadingError(e.to_string())).and_then(|s| {
+                    ron::from_str::<PaymentChannel<P, C, W, KES>>(&s)
+                        .map_err(|e| PaymentChannelError::LoadingError(e.to_string()))
+                })
+            } else {
+                Err(PaymentChannelError::LoadingError(format!(
+                    "{} is not a ron file",
+                    path.as_ref().display()
+                )))
+            }
+        } else {
+            Err(PaymentChannelError::LoadingError(format!(
+                "{} is not a channel file",
+                path.as_ref().display()
+            )))
+        }
+    }
+
+    pub fn peer_info(&self) -> ContactInfo {
+        self.peer_info.clone()
+    }
+
+    pub fn peer_address(&self) -> Multiaddr {
+        self.peer_info.address.clone()
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_info.peer_id
+    }
+
+    /// Returns the channel name, which is identical to `channel_id.name()`
+    pub fn name(&self) -> String {
+        self.state.current_state().name()
+    }
+}
+
+pub struct PaymentChannels<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    channels: Arc<RwLock<HashMap<String, Arc<RwLock<PaymentChannel<P, C, W, KES>>>>>>,
+}
+
+impl<P, C, W, KES> Clone for PaymentChannels<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    fn clone(&self) -> Self {
+        PaymentChannels { channels: Arc::clone(&self.channels) }
+    }
+}
+
+impl<P, C, W, KES> PaymentChannels<P, C, W, KES>
+where
+    P: PublicKey,
+    C: ActivePaymentChannel,
+    W: MultiSigWallet,
+    KES: KeyEscrowService,
+{
+    pub fn new() -> Self {
+        PaymentChannels { channels: Arc::new(RwLock::new(HashMap::new())) }
+    }
+
+    pub fn load<Pth: AsRef<Path>>(channel_dir: Pth) -> Result<Self, PaymentChannelError> {
+        let channel_dir = channel_dir.as_ref();
+        debug!("Loading channels from {}", channel_dir.display());
+        if !channel_dir.exists() {
+            info!("Channel directory does not exist: {}. Creating it now", channel_dir.display());
+            fs::create_dir_all(channel_dir)?;
+            return Ok(Self::new());
+        }
+        let mut channels = HashMap::new();
+        for entry in fs::read_dir(channel_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            match PaymentChannel::<P, C, W, KES>::try_load_from_file(&path) {
+                Ok(channel) => {
+                    let key = channel.name();
+                    let channel = Arc::new(RwLock::new(channel));
+                    channels.insert(key, channel);
+                }
+                Err(e) => {
+                    info!("Non- or invalid channel found in channels folder: {e}");
+                }
+            }
+        }
+        let channels = Self { channels: Arc::new(RwLock::new(channels)) };
+        Ok(channels)
+    }
+
+    pub async fn exists(&self, name: &str) -> bool {
+        let lock = self.channels.read().await;
+        lock.contains_key(name)
+    }
+
+    /// Add a new channel to the list of channels.
+    pub async fn add(&self, channel: PaymentChannel<P, C, W, KES>) {
+        let key = channel.name();
+        let channel = Arc::new(RwLock::new(channel));
+        let mut lock = self.channels.write().await;
+        lock.insert(key, channel);
+    }
+
+    /// Check the channel out for writing, if it exists.
+    /// If the channel is already checked out, this method will block until the channel is available.
+    /// If the channel does not exist, `checkout` returns None.
+    pub async fn checkout(&self, channel_name: &str) -> Option<OwnedRwLockWriteGuard<PaymentChannel<P, C, W, KES>>> {
+        let lock = self.channels.read().await;
+        match lock.get(channel_name) {
+            Some(lock) => {
+                let channel = lock.clone().write_owned().await;
+                Some(channel)
+            }
+            None => None,
+        }
+    }
+
+    /// Try and check the channel out for writing.
+    ///
+    /// If it does not exist or is already checked out, this method will return None.
+    pub async fn try_checkout(
+        &self,
+        channel_name: &str,
+    ) -> Option<OwnedRwLockWriteGuard<PaymentChannel<P, C, W, KES>>> {
+        let lock = self.channels.read().await;
+        lock.get(channel_name).cloned().and_then(|lock| lock.try_write_owned().ok())
+    }
+
+    pub async fn try_peek(&self, channel_name: &str) -> Option<OwnedRwLockReadGuard<PaymentChannel<P, C, W, KES>>> {
+        let lock = self.channels.read().await;
+        lock.get(channel_name).cloned().and_then(|lock| lock.try_read_owned().ok())
+    }
+
+    /// Stores the in-memory channels to the configured channel directory, overwriting any existing files.
+    pub async fn save_channels<Pth: AsRef<Path>>(&self, path: Pth) -> Result<(), PaymentChannelError> {
+        let lock = self.channels.read().await;
+        let channel_dir = path.as_ref();
+        fs::create_dir_all(channel_dir)?;
+        for (name, channel) in lock.iter() {
+            let path = channel_dir.join(format!("{name}.ron"));
+            let readable = channel.read().await;
+            let serialized = ron::to_string::<PaymentChannel<P, C, W, KES>>(&readable)?;
+            drop(readable);
+            fs::write(path, serialized)?;
+        }
+        Ok(())
+    }
+
+    /// Provides a list of channels, which can be used to index the channels
+    pub async fn list_channels(&self) -> Vec<String> {
+        let lock = self.channels.read().await;
+        lock.keys().cloned().collect()
+    }
+}


### PR DESCRIPTION
# Summary
This commit introduces significant updates and refactoring to the payment channel implementation

## Key Changes
1. **State Machine Enhancements**:
   - Added `NewChannelState` to the `state_machine` module.
   - Replaced `my_partial_channel_id` and `peer_partial_channel_id` with `my_label` and `peer_label` for better clarity
   - Updated `NewChannelBuilder` and `NewChannelState` to reflect these changes.
   - Introduced `for_proposal` method in `NewChannelState` to convert state into a proposal.

2. **P2P Module Updates**:
   - Added support for generic `PublicKey` in `ConnectionBehavior`, `EventLoop`, and related types.
   - Introduced `GreaseChannelDelegate` trait for handling payment channel operations.
   - Added `DummyDelegate` as a default implementation of `GreaseChannelDelegate`.
   - Refactored `GreaseRequest` and `GreaseResponse` to support generic `PublicKey` and added new variants like `ChannelNotFound`.
   - Updated `ClientCommand` and `PeerConnectionEvent` to handle channel proposals and responses generically.

3. **New Payment Channel Module**:
   - Added `PaymentChannel` and `PaymentChannels` structs to manage individual and multiple payment channels.
   - Implemented methods for loading, saving, and managing channels, including file-based persistence using RON serialization.

4. **Key Management**:
   - Introduced `KeyManager` trait for managing keypairs and validating keys.
   - Added `KeyDelegate` trait for key-related operations.

5. **Server Implementation**:
   - Added `NetworkServer` to handle P2P communication and payment channel operations.
   - Implemented logic for handling incoming channel proposals and verifying them using `GreaseChannelDelegate`.

6. **Identity and Contact Info**:
   - Updated `ConversationIdentity` to require an address and provide a `dial_address` method.
   - Refactored `ContactInfo` to include serialization and deserialization logic for `PeerId`.

7. **Error Handling**:
   - Added new error variants in `PaymentChannelError` and `PeerConnectionError` for better error reporting.

8. **Dependency Updates**:
   - Added `blake2` and `ron` crates for hashing and serialization.
   - Removed unused `blake` crate.

- Updated tests to reflect changes in `ConversationIdentity` and `NewChannelBuilder`.
- Improved logging and error handling for better debugging and traceability.
- Ensured backward compatibility by maintaining existing functionality while introducing new features.

This refactor lays the groundwork for more robust and scalable payment channel operations in the grease framework.

feat: channel proposal logic

Bringing in Channel Proposal logic.

This includes:
- Code to persist and load Channel state to disk (FileStore)
- Remove blake crate in favour of Blake2b everywhere
- Add menu item for Chanel Proposal

chore: refactor

Move common request-response logic to p2p, and introduce the Delegate worker trait.

Add Send+Sync to trait bounds so that the state can be passed between tokio threads.

refactor: integrate channels and network

fix: make channel ids consistent

Fixes bug where the channel id swapped the order of labels for merchants and users.

Both parties have the same channel id now for the same channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added generic support for cryptographic keys across P2P networking and payment channels.
  - Introduced a modular delegate system for channel proposal verification.
  - Implemented a network server managing peer-to-peer payment channels with full lifecycle handling.
  - Added a unified channel proposal result type for acceptance and rejection.
  - Enhanced CLI with a new keypair generation command and streamlined server startup.
  - Introduced generic event loop and network client supporting flexible key types.

- **Improvements**
  - Simplified identity handling with mandatory network addresses and dial address generation.
  - Improved concurrency and async access to payment channels with Tokio RwLocks.
  - Replaced Blake hashing with Blake2b for consistency and security.
  - Enhanced error handling with detailed channel and payment errors.
  - Refined trait bounds to enforce thread safety and clonability across components.
  - Updated naming conventions from partial channel IDs to user labels for clarity.

- **Bug Fixes**
  - Fixed ordering implementation for Monero amounts.
  - Corrected hashing parameter passing and cloning inefficiencies.

- **Refactor**
  - Modularized P2P message types and client commands with generic public key parameters.
  - Removed legacy network server code, consolidating to a new generic server implementation.
  - Reorganized state machine and channel lifecycle code with added cloning and role methods.
  - Replaced manual struct definitions with type aliases specializing generic payment channel types.

- **Chores**
  - Updated dependencies to use workspace-managed crates and removed unused ones.
  - Cleaned up unused imports and deprecated CLI arguments.
  - Added new public modules and exports for extended functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->