### PR TITLE
refactor: improve channel creation flow

### DIFF
--- a/grease_cli/src/interactive/mod.rs
+++ b/grease_cli/src/interactive/mod.rs
@@ -161,33 +161,18 @@ impl InteractiveApp {
         let (secret, proposal) = self.create_channel_proposal(oob_info)?;
         trace!("Generated new proposal");
         // Send the proposal to the merchant and wait for reply
-        let result = self.server.send_proposal(proposal.clone()).await?;
+        let result = self.server.send_proposal(secret, proposal.clone()).await?;
         match result {
             // We got an ack, but the merchant may have changed the proposal, so we need to check.
-            ChannelProposalResult::Accepted(final_proposal) => {
-                debug!("Channel proposal ACK received.");
-                info!("Received channel proposal response. Validating results...");
-                let state = self.create_new_state(secret, proposal)?;
-                let (channel, result) = self.create_channel(state, final_proposal);
-                let msg = match result {
-                    Ok(_) => {
-                        info!("🥂 Channel proposal accepted.");
-                        "🥂 Channel proposal accepted"
-                    }
-                    Err(err) => {
-                        warn!("😢 We cannot accept the channel creation terms: {err}");
-                        "😢 We cannot accept the channel creation terms"
-                    }
-                };
-                let name = channel.name();
-                self.channel_status = Some(channel.state().stage());
-                self.server.add_channel(channel).await;
+            Ok(name) => {
                 self.save_channels().await?;
                 info!("Channels saved.");
                 self.current_channel = Some(name.clone());
-                Ok(format!("{msg} for {name}"))
+                let status = self.server.channel_status(&name).await;
+                self.channel_status = status;
+                Ok(format!("New channel created: {name}"))
             }
-            ChannelProposalResult::Rejected(rej) => {
+            Err(rej) => {
                 warn!("Channel proposal rejected: {}", rej.reason);
                 // todo: handle the rejection based on retry options
                 Err(anyhow!("Channel proposal rejected"))
@@ -208,40 +193,6 @@ impl InteractiveApp {
         let my_user_label = format!("{user_label}-{key_index}");
         let proposal = NewChannelProposal::new(seed_info, my_pubkey, my_user_label, my_contact_info, peer_info);
         Ok((my_secret, proposal))
-    }
-
-    fn create_new_state(
-        &self,
-        secret: Curve25519Secret,
-        prop: NewChannelProposal<Curve25519PublicKey>,
-    ) -> Result<NewChannelState<Curve25519PublicKey>> {
-        let new_state = MoneroChannelBuilder::new(prop.seed.role, prop.proposer_pubkey, secret)
-            .with_my_user_label(&prop.proposer_label)
-            .with_peer_label(&prop.seed.user_label)
-            .with_merchant_initial_balance(prop.seed.initial_balances.merchant)
-            .with_customer_initial_balance(prop.seed.initial_balances.customer)
-            .with_peer_public_key(prop.seed.pubkey)
-            .with_kes_public_key(prop.seed.kes_public_key)
-            .build::<blake2::Blake2b512>()
-            .ok_or_else(|| anyhow!("Missing new channel state data"))?;
-        Ok(new_state)
-    }
-
-    /// Creates a new channel, given the initial `NewChannelState` and then emits `AckNewChannel` event, which
-    /// verifies that everything is correct and the channel can be created.
-    ///
-    /// If we exit here successfully, the channel will be in the `Establishing` phase.
-    /// Otherwise, something has gone wrong and the channel should be `Closed`.
-    pub fn create_channel(
-        &mut self,
-        new_state: NewChannelState<Curve25519PublicKey>,
-        final_prop: NewChannelProposal<Curve25519PublicKey>,
-    ) -> (MoneroPaymentChannel, Result<(), LifeCycleError>) {
-        let peer_info = final_prop.contact_info_proposee.clone();
-        let state = MoneroLifeCycle::New(Box::new(new_state));
-        let mut channel = MoneroPaymentChannel::new(peer_info, state);
-        let result = channel.receive_proposal_ack(final_prop);
-        (channel, result)
     }
 
     /// Lists all available identities from the configuration.

--- a/grease_cli/src/launch_app.rs
+++ b/grease_cli/src/launch_app.rs
@@ -27,7 +27,7 @@ async fn run_interactive(global_options: GlobalOptions) {
         Err(e) => error!("Error saving channels: {}", e),
     }
     match result {
-        Ok(_) => println!("Bye!"),
+        Ok(_) => println!("Server shut down successfully."),
         Err(e) => error!("Session ended with error: {}", e),
     }
 }

--- a/grease_cli/src/lib.rs
+++ b/grease_cli/src/lib.rs
@@ -3,5 +3,5 @@ pub mod config;
 pub mod error;
 pub mod id_management;
 pub mod interactive;
+pub mod launch_app;
 pub mod other_commands;
-pub mod server;

--- a/grease_cli/src/main.rs
+++ b/grease_cli/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use grease_cli::config::{CliCommand, CliOptions, GlobalOptions};
 use grease_cli::id_management::exec_id_command;
+use grease_cli::launch_app::start;
 use grease_cli::other_commands::print_random_keypair;
-use grease_cli::server::start;
 use libgrease::crypto::keys::Curve25519PublicKey;
 
 #[tokio::main]


### PR DESCRIPTION
The Channel Proposal logic for the customer now sites in p2p::server where it belongs, and interactive/mod.rs is just send->respond.

It's much cleaner now.

Also renamed cli/server so that there's only one server.rs file in this project.