### PR TITLE
feat: correct multisig wallet negotiation

### DIFF
--- a/grease_cli/src/interactive/mod.rs
+++ b/grease_cli/src/interactive/mod.rs
@@ -44,7 +44,7 @@ impl InteractiveApp {
         let key_manager = MoneroKeyManager::new(secret);
         let id_path = config.identities_file.clone().unwrap_or_else(|| config.base_path().join("identities.yml"));
         let identity = assign_identity(&id_path, config.preferred_identity.as_ref())?;
-        let delegate = DummyDelegate;
+        let delegate = DummyDelegate::default();
         let channels = PaymentChannels::load(config.channel_directory())?;
         let server = MoneroNetworkServer::new(identity.clone(), channels, delegate, key_manager)?;
         let app =

--- a/libgrease/Cargo.toml
+++ b/libgrease/Cargo.toml
@@ -15,7 +15,7 @@ blake2 = { workspace = true }
 curve25519-dalek = { version = "4.1.3", features = ["digest"] }
 digest = "0.10.7"
 hex = "0.4.3"
-monero = { workspace = true }
+monero = { workspace = true, features = ["serde"] }
 rand = { workspace = true }
 thiserror = "2.0.12"
 log = "0.4.27"

--- a/libgrease/src/crypto/traits.rs
+++ b/libgrease/src/crypto/traits.rs
@@ -1,10 +1,11 @@
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 pub trait SecretKey: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> {}
 
 pub trait PublicKey: Clone + PartialEq + Eq + Send + Sync + Serialize + for<'de> Deserialize<'de> {
-    type SecretKey: SecretKey;
+    type SecretKey: SecretKey + Debug;
 
     fn keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (Self::SecretKey, Self);
     fn from_secret(secret_key: &Self::SecretKey) -> Self;

--- a/libgrease/src/file_store.rs
+++ b/libgrease/src/file_store.rs
@@ -69,7 +69,7 @@ mod test {
         let path = PathBuf::from("./test_data");
         let mut store = FileStore::new(path).expect("directory to exist");
         let (mut lc, initial_state) = new_channel_state();
-        let name = initial_state.channel_id.name();
+        let name = initial_state.channel_info.channel_id.name();
         store.write_channel(&lc).expect("Failed to write channel");
         lc = store.load_channel(&name).expect("Failed to load channel");
         lc = accept_proposal(lc, &initial_state).await;

--- a/libgrease/src/kes/data_objects.rs
+++ b/libgrease/src/kes/data_objects.rs
@@ -1,0 +1,27 @@
+use crate::state_machine::Balances;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartialEncryptedKey(pub String);
+
+#[derive(Debug, Clone)]
+pub struct KesId(String);
+
+#[derive(Debug, Clone)]
+pub struct KesInitializationRecord {
+    pub kes_public_key: String,
+    pub channel_id: String,
+    pub initial_balances: Balances,
+    pub merchant_key: PartialEncryptedKey,
+    pub customer_key: PartialEncryptedKey,
+}
+
+pub struct KesInitializationResult {
+    pub id: KesId,
+}
+
+impl From<String> for KesId {
+    fn from(channel_id: String) -> Self {
+        KesId(channel_id)
+    }
+}

--- a/libgrease/src/kes/dummy_impl.rs
+++ b/libgrease/src/kes/dummy_impl.rs
@@ -1,14 +1,16 @@
-use crate::kes::traits::{KesError, KesIinitializationRecord};
-use crate::kes::KeyEscrowService;
-use log::info;
+use crate::kes::data_objects::KesInitializationResult;
+use crate::kes::error::KesError;
+use crate::kes::{KesInitializationRecord, KeyEscrowService};
+use log::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DummyKes;
 
 impl KeyEscrowService for DummyKes {
-    async fn initialize(_init: KesIinitializationRecord) -> Result<Self, KesError> {
+    async fn initialize(&self, init: KesInitializationRecord) -> Result<KesInitializationResult, KesError> {
         info!("Dummy KES initialized");
-        Ok(DummyKes)
+        let result = KesInitializationResult { id: init.channel_id.into() };
+        Ok(result)
     }
 }

--- a/libgrease/src/kes/error.rs
+++ b/libgrease/src/kes/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
+pub enum KesError {
+    #[error("KES initialization failed: {0}")]
+    InitializationError(String),
+}

--- a/libgrease/src/kes/mod.rs
+++ b/libgrease/src/kes/mod.rs
@@ -1,5 +1,8 @@
+mod data_objects;
 #[cfg(feature = "dummy_channel")]
 pub mod dummy_impl;
+pub mod error;
 mod traits;
 
+pub use data_objects::{KesInitializationRecord, KesInitializationResult, PartialEncryptedKey};
 pub use traits::KeyEscrowService;

--- a/libgrease/src/kes/traits.rs
+++ b/libgrease/src/kes/traits.rs
@@ -1,24 +1,13 @@
-use crate::state_machine::Balances;
+use crate::kes::data_objects::KesInitializationResult;
+use crate::kes::error::KesError;
+use crate::kes::KesInitializationRecord;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
-use thiserror::Error;
-
-pub struct PartialEncryptedKey(pub String);
-
-pub struct KesIinitializationRecord {
-    pub kes_public_key: String,
-    pub channel_id: String,
-    pub initial_balances: Balances,
-    pub merchant_key: PartialEncryptedKey,
-    pub customer_key: PartialEncryptedKey,
-}
-
-#[derive(Clone, Debug, Error)]
-pub enum KesError {
-    #[error("KES initialization failed: {0}")]
-    InitializationError(String),
-}
 
 pub trait KeyEscrowService: Serialize + for<'de> Deserialize<'de> + Send + Sync {
-    fn initialize(init: KesIinitializationRecord) -> impl Future<Output = Result<Self, KesError>> + Send;
+    /// Create a new escrow with the information in `init`.
+    fn initialize(
+        &self,
+        init: KesInitializationRecord,
+    ) -> impl Future<Output = Result<KesInitializationResult, KesError>> + Send;
 }

--- a/libgrease/src/monero/helpers.rs
+++ b/libgrease/src/monero/helpers.rs
@@ -1,0 +1,54 @@
+use monero::{KeyPair, PrivateKey};
+use serde::{Deserialize, Deserializer};
+
+pub fn deserialize_keypair<'de, D>(de: D) -> Result<KeyPair, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let encoded = String::deserialize(de)?;
+    if encoded.len() != 128 {
+        return Err(serde::de::Error::custom("Invalid length"));
+    }
+    let mut bytes = hex::decode(encoded).map_err(serde::de::Error::custom)?;
+    let spend = PrivateKey::from_slice(&mut bytes[0..32])
+        .map_err(|_| serde::de::Error::custom("Invalid spend key encoding"))?;
+    let view = PrivateKey::from_slice(&mut bytes[32..64])
+        .map_err(|_| serde::de::Error::custom("Invalid view key encoding"))?;
+    Ok(KeyPair { spend, view })
+}
+
+pub fn serialize_keypair<S>(key: &KeyPair, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut bytes = [0u8; 64];
+    bytes[0..32].copy_from_slice(&key.spend.as_bytes());
+    bytes[32..64].copy_from_slice(&key.view.as_bytes());
+    let encoded = hex::encode(bytes);
+    s.serialize_str(&encoded)
+}
+
+pub fn serialize_network<S>(network: &monero::Network, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let network_str = match network {
+        monero::Network::Mainnet => "mainnet",
+        monero::Network::Stagenet => "stagenet",
+        monero::Network::Testnet => "testnet",
+    };
+    s.serialize_str(network_str)
+}
+
+pub fn deserialize_network<'de, D>(de: D) -> Result<monero::Network, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let network_str = String::deserialize(de)?;
+    match network_str.as_str() {
+        "mainnet" => Ok(monero::Network::Mainnet),
+        "stagenet" => Ok(monero::Network::Stagenet),
+        "testnet" => Ok(monero::Network::Testnet),
+        _ => Err(serde::de::Error::custom("Invalid network type")),
+    }
+}

--- a/libgrease/src/monero/mod.rs
+++ b/libgrease/src/monero/mod.rs
@@ -2,8 +2,9 @@ pub mod data_objects;
 #[cfg(feature = "dummy_channel")]
 pub mod dummy_impl;
 pub mod error;
+pub mod helpers;
 mod state_machine;
 mod traits;
 
 pub use state_machine::WalletState;
-pub use traits::MultiSigWallet;
+pub use traits::{MoneroKeyPair, MoneroPrivateKey, MultiSigWallet, Network};

--- a/libgrease/src/monero/traits.rs
+++ b/libgrease/src/monero/traits.rs
@@ -13,6 +13,10 @@ use crate::monero::error::MoneroWalletError;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 
+pub type MoneroPrivateKey = monero::PrivateKey;
+pub type MoneroKeyPair = monero::KeyPair;
+pub use monero::Network;
+
 /// Interface for a 2-of-2 Monero multisig wallet implementation
 #[allow(async_fn_in_trait)]
 pub trait MultiSigWallet: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync {
@@ -57,6 +61,13 @@ pub trait MultiSigWallet: Clone + Serialize + for<'de> Deserialize<'de> + Send +
     fn get_address(&self) -> impl Future<Output = MoneroAddress> + Send;
     async fn get_view_key(&self) -> MoneroViewKey;
     async fn get_balance(&self) -> Result<WalletBalance, MoneroWalletError>;
+
+    /// Generate a new key pair for the wallet. This is used for the multisig protocol.
+    fn generate_key_pair(&self) -> MoneroKeyPair;
+
+    fn address_from_keypair(&self, network: Network, keypair: &MoneroKeyPair) -> MoneroAddress {
+        MoneroAddress::from_keypair(network, keypair)
+    }
 
     async fn get_seed(&self) -> Result<MultiSigSeed, MoneroWalletError>;
     async fn restore_from_seed(seed: MultiSigSeed) -> Result<Self, MoneroWalletError>;

--- a/libgrease/src/state_machine/disputing_channel.rs
+++ b/libgrease/src/state_machine/disputing_channel.rs
@@ -4,7 +4,7 @@ use crate::kes::KeyEscrowService;
 use crate::monero::MultiSigWallet;
 use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
 use crate::state_machine::traits::ChannelState;
-use crate::state_machine::{ClosingChannelState, EstablishedChannelState};
+use crate::state_machine::{ChannelMetadata, ClosingChannelState, EstablishedChannelState};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -19,10 +19,10 @@ where
 {
     pub(crate) origin: DisputeOrigin,
     pub(crate) reason: String,
-    pub(crate) secret: P::SecretKey,
     pub(crate) payment_channel: C,
     pub(crate) wallet: W,
     pub(crate) kes: KES,
+    pub(crate) channel_info: ChannelMetadata<P>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,10 +69,10 @@ where
         DisputingChannelState {
             origin: info.origin,
             reason: info.reason,
-            secret: open_state.channel_info.secret_key,
             payment_channel: open_state.payment_channel,
             wallet: open_state.wallet,
             kes: open_state.kes,
+            channel_info: open_state.channel_info,
         }
     }
 
@@ -80,10 +80,10 @@ where
         DisputingChannelState {
             origin: info.origin,
             reason: info.reason,
-            secret: closing_state.channel_info.secret_key,
             payment_channel: closing_state.payment_channel,
             wallet: closing_state.wallet,
             kes: closing_state.kes,
+            channel_info: closing_state.channel_info,
         }
     }
 }

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -1,14 +1,15 @@
 use crate::amount::MoneroAmount;
 use crate::channel_id::ChannelId;
 use crate::crypto::traits::PublicKey;
-use crate::kes::KeyEscrowService;
-use crate::monero::{MultiSigWallet, WalletState};
+use crate::kes::{KeyEscrowService, PartialEncryptedKey};
+use crate::monero::error::MoneroWalletError;
+use crate::monero::{MoneroKeyPair, MultiSigWallet, WalletState};
 use crate::payment_channel::ActivePaymentChannel;
 use crate::payment_channel::ChannelRole;
 use crate::state_machine::traits::ChannelState;
+use monero::Network;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
-
 //------------------------------------   Establishing Channel State  ------------------------------------------------//
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -17,10 +18,21 @@ pub struct ChannelMetadata<P>
 where
     P: PublicKey,
 {
+    /// The Monero network this channel lives on
+    #[serde(
+        deserialize_with = "crate::monero::helpers::deserialize_network",
+        serialize_with = "crate::monero::helpers::serialize_network"
+    )]
+    pub network: Network,
+    /// Whether we are the merchant or the customer
     pub role: ChannelRole,
-    pub(crate) secret_key: P::SecretKey,
+    /// The key that is used to decrypt the peer's multisig secret share.
+    pub(crate) decryption_key: P::SecretKey,
+    /// The key used to encrypt the merchant's portion of the customer's multisig spend key.
     pub merchant_pubkey: P,
+    /// The key used to encrypt the customer's portion of the merchant's multisig spend key.
     pub customer_pubkey: P,
+    /// The key both peers use to encrypt their portion of the multisig spend key.
     pub kes_public_key: P,
     /// The amount of money in the channel
     pub initial_balances: Balances,
@@ -71,7 +83,7 @@ where
     W: MultiSigWallet,
 {
     pub fn new(channel_info: ChannelMetadata<P>, uninitialized_wallet: W) -> Self {
-        let wallet_state = Some(WalletState::new(uninitialized_wallet));
+        let wallet_state = Some(WalletState::new(channel_info.network, uninitialized_wallet));
         EstablishingState { channel_info, wallet_state }
     }
 
@@ -90,6 +102,12 @@ where
     {
         let wallet_state = self.wallet_state.take().expect("Wallet state has been removed");
         let new_wallet_state = update(wallet_state).await;
+        self.wallet_state = Some(new_wallet_state);
+    }
+
+    pub fn update_wallet_state_sync(&mut self, update: impl FnOnce(WalletState<W>) -> WalletState<W>) {
+        let wallet_state = self.wallet_state.take().expect("Wallet state has been removed");
+        let new_wallet_state = update(wallet_state);
         self.wallet_state = Some(new_wallet_state);
     }
 }
@@ -116,6 +134,11 @@ where
     W: MultiSigWallet,
 {
     pub channel_info: ChannelMetadata<P>,
+    #[serde(
+        deserialize_with = "crate::monero::helpers::deserialize_keypair",
+        serialize_with = "crate::monero::helpers::serialize_keypair"
+    )]
+    pub wallet_secret: MoneroKeyPair,
     pub wallet: W,
 }
 
@@ -129,6 +152,31 @@ where
     }
     fn role(&self) -> ChannelRole {
         self.channel_info.role
+    }
+}
+
+impl<P, W> WalletCreatedState<P, W>
+where
+    P: PublicKey,
+    W: MultiSigWallet,
+{
+    /// Returns the information needed to create the Verifiable Secret Sharing (VSS) record.
+    ///
+    /// In particular, it returns
+    /// - our secret key
+    /// - the public key of the merchant
+    /// - the public key of the KES
+    pub fn vss_info(&self) -> Result<ChannelInitSecrets<P>, MoneroWalletError> {
+        let peer_public_key = match self.channel_info.role {
+            ChannelRole::Merchant => self.channel_info.customer_pubkey.clone(),
+            ChannelRole::Customer => self.channel_info.merchant_pubkey.clone(),
+        };
+        Ok(ChannelInitSecrets {
+            channel_name: self.name(),
+            wallet_secret: self.wallet_secret.clone(),
+            peer_public_key,
+            kes_public_key: self.channel_info.kes_public_key.clone(),
+        })
     }
 }
 
@@ -193,4 +241,31 @@ impl Balances {
             Balances::new(new_merchant, new_customer)
         })
     }
+}
+
+//------------------------------------           VSS Info          ------------------------------------------------//
+
+/// Contains information needed to initialise the KES and create the VSS record.
+///
+/// This object contains a SECRET key and should be handled with care!
+#[derive(Debug)]
+pub struct ChannelInitSecrets<P>
+where
+    P: PublicKey,
+{
+    pub channel_name: String,
+    /// My portion of the 2-of-2 multisig secret that needs to be split
+    wallet_secret: MoneroKeyPair,
+    /// The public key of the peer
+    pub peer_public_key: P,
+    /// The public key of the KES. One secret shard will be encrypted to this key.
+    pub kes_public_key: P,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VssOutput {
+    /// The encrypted secret shard for the peer
+    pub peer_shard: PartialEncryptedKey,
+    /// The encrypted secret shard for the KES
+    pub kes_shard: PartialEncryptedKey,
 }

--- a/libgrease/src/state_machine/mod.rs
+++ b/libgrease/src/state_machine/mod.rs
@@ -15,7 +15,7 @@ pub mod traits;
 pub use closed_channel::{ChannelClosedReason, ClosedChannelState};
 pub use closing_channel::{ClosingChannelState, StartCloseInfo, SuccessfulCloseInfo};
 pub use disputing_channel::{DisputeOrigin, DisputeResolvedInfo, DisputingChannelState, ForceCloseInfo};
-pub use establishing_channel::{Balances, ChannelMetadata};
+pub use establishing_channel::{Balances, ChannelInitSecrets, ChannelMetadata, VssOutput};
 pub use lifecycle::{ChannelLifeCycle, LifecycleStage};
 pub use new_channel::{ChannelSeedBuilder, ChannelSeedInfo, NewChannelBuilder, NewChannelState, ProposedChannelInfo};
 pub use open_channel::EstablishedChannelState;

--- a/libgrease/src/state_machine/new_channel.rs
+++ b/libgrease/src/state_machine/new_channel.rs
@@ -5,9 +5,10 @@ use crate::payment_channel::ChannelRole;
 use crate::state_machine::error::InvalidProposal;
 use crate::state_machine::establishing_channel::Balances;
 use crate::state_machine::traits::ChannelState;
-use crate::state_machine::LifecycleStage;
+use crate::state_machine::{ChannelMetadata, LifecycleStage};
 use digest::Digest;
 use log::debug;
+use monero::Network;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -19,9 +20,11 @@ use thiserror::Error;
 /// structured around a builder pattern. Both merchant and customer get the necessary info from "somewhere". In
 /// practice, it'll be a QR code or deep link, or a direct RPC call from the customer.
 pub struct NewChannelBuilder<P: PublicKey> {
+    network: Option<Network>,
     channel_role: ChannelRole,
     my_public_key: P,
-    my_secret_key: P::SecretKey,
+    // This secret is used to decrypt the secret shares in the case of a dispute
+    my_decryption_key: P::SecretKey,
     kes_public_key: Option<P>,
     my_label: Option<String>,
     peer_public_key: Option<P>,
@@ -47,9 +50,10 @@ impl RejectNewChannelReason {
 impl<P: PublicKey> NewChannelBuilder<P> {
     pub fn new(channel_role: ChannelRole, my_public_key: P, my_secret_key: P::SecretKey) -> Self {
         NewChannelBuilder {
+            network: None,
             channel_role,
             my_public_key,
-            my_secret_key,
+            my_decryption_key: my_secret_key,
             kes_public_key: None,
             my_label: None,
             peer_public_key: None,
@@ -83,16 +87,20 @@ impl<P: PublicKey> NewChannelBuilder<P> {
             ChannelRole::Merchant => (self.my_public_key.clone(), self.peer_public_key.clone().unwrap()),
             ChannelRole::Customer => (self.peer_public_key.clone().unwrap(), self.my_public_key.clone()),
         };
-        Some(NewChannelState {
+        let channel_info = ChannelMetadata {
+            network: self.network.unwrap_or(Network::Mainnet),
             role: self.channel_role,
+            decryption_key: self.my_decryption_key.clone(),
             merchant_pubkey,
             customer_pubkey,
             kes_public_key: self.kes_public_key.clone().unwrap(),
-            secret_key: self.my_secret_key.clone(),
             initial_balances,
+            channel_id,
+        };
+        Some(NewChannelState {
+            channel_info,
             customer_label: self.my_label.clone().unwrap(),
             merchant_label: self.peer_label.clone().unwrap(),
-            channel_id,
         })
     }
 
@@ -134,24 +142,10 @@ pub struct NewChannelState<P>
 where
     P: PublicKey,
 {
-    /// My role, whether customer or merchant
-    pub role: ChannelRole,
-    /// My secret key for the 2-of-2 multisig wallet
-    pub(crate) secret_key: P::SecretKey,
-    /// The public key of the merchant, for use in adaptor signatures
-    pub merchant_pubkey: P,
-    /// The public key of the customer, for use in adaptor signatures
-    pub customer_pubkey: P,
-    /// The public key of the KES key, for encrypting the secret share
-    pub kes_public_key: P,
-    /// The amount of money in the channel
-    pub initial_balances: Balances,
-    /// Salt used to derive the channel ID - customer portion
+    pub channel_info: ChannelMetadata<P>,
     pub customer_label: String,
     /// Salt used to derive the channel ID - merchant portion
     pub merchant_label: String,
-    /// The channel ID
-    pub channel_id: ChannelId,
 }
 
 impl<P: PublicKey> NewChannelState<P> {
@@ -159,22 +153,22 @@ impl<P: PublicKey> NewChannelState<P> {
     /// her initially.
     pub fn review_proposal(&self, proposal: &ProposedChannelInfo<P>) -> Result<(), InvalidProposal> {
         debug!("Internal sanity check on proposal info");
-        if self.role != proposal.role {
+        if self.channel_info.role != proposal.role {
             return Err(InvalidProposal::IncompatibleRoles);
         }
-        if self.initial_balances != proposal.initial_balances {
+        if self.channel_info.initial_balances != proposal.initial_balances {
             return Err(InvalidProposal::MismatchedBalances);
         }
-        if self.merchant_pubkey != proposal.merchant_pubkey {
+        if self.channel_info.merchant_pubkey != proposal.merchant_pubkey {
             return Err(InvalidProposal::MismatchedMerchantPublicKey);
         }
-        if self.customer_pubkey != proposal.customer_pubkey {
+        if self.channel_info.customer_pubkey != proposal.customer_pubkey {
             return Err(InvalidProposal::MismatchedCustomerPublicKey);
         }
-        if self.kes_public_key != proposal.kes_public_key {
+        if self.channel_info.kes_public_key != proposal.kes_public_key {
             return Err(InvalidProposal::MismatchedKesPublicKey);
         }
-        if self.channel_id != proposal.channel_id {
+        if self.channel_info.channel_id != proposal.channel_id {
             return Err(InvalidProposal::MismatchedChannelId);
         }
         Ok(())
@@ -183,25 +177,25 @@ impl<P: PublicKey> NewChannelState<P> {
     /// Convert this state (which contains a secret key) into a proposal (which does not).
     pub fn for_proposal(&self) -> ProposedChannelInfo<P> {
         ProposedChannelInfo {
-            role: self.role,
-            merchant_pubkey: self.merchant_pubkey.clone(),
-            customer_pubkey: self.customer_pubkey.clone(),
-            kes_public_key: self.kes_public_key.clone(),
-            initial_balances: self.initial_balances,
+            role: self.channel_info.role,
+            merchant_pubkey: self.channel_info.merchant_pubkey.clone(),
+            customer_pubkey: self.channel_info.customer_pubkey.clone(),
+            kes_public_key: self.channel_info.kes_public_key.clone(),
+            initial_balances: self.channel_info.initial_balances,
             customer_label: self.customer_label.clone(),
             merchant_label: self.merchant_label.clone(),
-            channel_id: self.channel_id.clone(),
+            channel_id: self.channel_info.channel_id.clone(),
         }
     }
 }
 
 impl<P: PublicKey> ChannelState for NewChannelState<P> {
     fn channel_id(&self) -> &ChannelId {
-        &self.channel_id
+        &self.channel_info.channel_id
     }
 
     fn role(&self) -> ChannelRole {
-        self.role
+        self.channel_info.role
     }
 }
 

--- a/p2p/src/errors.rs
+++ b/p2p/src/errors.rs
@@ -1,4 +1,7 @@
 use futures::channel::{mpsc, oneshot};
+use libgrease::kes::error::KesError;
+use libgrease::monero::error::MoneroWalletError;
+use libgrease::state_machine::error::LifeCycleError;
 use libp2p::{noise, TransportError};
 use std::convert::Infallible;
 use thiserror::Error;
@@ -33,4 +36,34 @@ pub enum PaymentChannelError {
     IOError(#[from] std::io::Error),
     #[error("Error serializing channel. {0}")]
     SerializationError(#[from] ron::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum ChannelServerError {
+    #[error("Channel is not in the Merchant role.")]
+    NotMerchantRole,
+    #[error("Channel is not in the Customer role.")]
+    NotCustomerRole,
+    #[error("Channel is in an invalid state. {0}")]
+    InvalidState(String),
+    #[error("Channel not found.")]
+    ChannelNotFound,
+    #[error("Error Setting up wallet. {0}")]
+    WalletSetup(#[from] MoneroWalletError),
+    #[error("Secret sharing failure. {0}")]
+    VssFailure(String),
+    #[error("Error communicating with peer. {0}")]
+    PeerConnectionError(#[from] PeerConnectionError),
+    #[error("The peer rejected the protocol. {0}")]
+    PeerCommsError(String),
+    #[error("Lifecycle state machine error. {0}")]
+    LifeCycleError(#[from] LifeCycleError),
+    #[error("An error Occurred with the KES. {0}")]
+    KesError(#[from] KesError),
+}
+
+#[derive(Error, Debug)]
+#[error("Verifiable Secret Sharing failure due to {reason}")]
+pub struct VssError {
+    pub reason: String,
 }

--- a/p2p/src/event_loop.rs
+++ b/p2p/src/event_loop.rs
@@ -12,7 +12,8 @@ use futures::channel::{
 };
 use futures::{SinkExt, StreamExt};
 use libgrease::crypto::traits::PublicKey;
-use libgrease::monero::data_objects::{MultiSigInitInfo, MultisigKeyInfo, RequestEnvelope};
+use libgrease::monero::data_objects::{MessageEnvelope, MsKeyAndVssInfo, MultiSigInitInfo};
+use libgrease::state_machine::VssOutput;
 use libp2p::core::transport::ListenerId;
 use libp2p::core::ConnectedPoint;
 use libp2p::identify::Event as IdentifyEvent;
@@ -75,10 +76,10 @@ pub struct EventLoop<P: PublicKey + 'static> {
     pending_dial: HashMap<PeerId, oneshot::Sender<Result<(), PeerConnectionError>>>,
     pending_new_channel_proposals: HashMap<OutboundRequestId, oneshot::Sender<ChannelProposalResult<P>>>,
     pending_multisig_inits:
-        HashMap<OutboundRequestId, oneshot::Sender<Result<RequestEnvelope<MultiSigInitInfo>, String>>>,
+        HashMap<OutboundRequestId, oneshot::Sender<Result<MessageEnvelope<MultiSigInitInfo>, String>>>,
     pending_multisig_keys:
-        HashMap<OutboundRequestId, oneshot::Sender<Result<RequestEnvelope<MultisigKeyInfo>, String>>>,
-    pending_address_confirmations: HashMap<OutboundRequestId, oneshot::Sender<Result<RequestEnvelope<bool>, String>>>,
+        HashMap<OutboundRequestId, oneshot::Sender<Result<MessageEnvelope<MsKeyAndVssInfo>, String>>>,
+    pending_address_confirmations: HashMap<OutboundRequestId, oneshot::Sender<Result<MessageEnvelope<bool>, String>>>,
     pending_shutdown: Option<oneshot::Sender<bool>>,
     status: AtomicUsize,
     connections: HashSet<ConnectionId>,
@@ -569,24 +570,21 @@ impl<P: PublicKey + Send> EventLoop<P> {
     }
 
     async fn handle_command(&mut self, command: ClientCommand<P>) {
+        self.command_handler(command).await.unwrap_or(())
+    }
+
+    async fn command_handler(&mut self, command: ClientCommand<P>) -> Result<(), ()> {
         match command {
             ClientCommand::StartListening { addr, sender } => {
-                if !self.is_running() {
-                    info!("Event loop is shutting down. I'm not going to start listening now.");
-                    let _ = sender.send(Err(PeerConnectionError::EventLoopShuttingDown));
-                    return;
-                }
+                let sender = self.abort_if_shutting_down(sender, PeerConnectionError::EventLoopShuttingDown)?;
                 let _ = match self.swarm.listen_on(addr) {
                     Ok(_) => sender.send(Ok(())),
                     Err(e) => sender.send(Err(PeerConnectionError::TransportError(e))),
                 };
+                Ok(())
             }
             ClientCommand::Dial { peer_id, peer_addr, sender } => {
-                if !self.is_running() {
-                    info!("Event loop is shutting down. I'm not going to dial anyone now.");
-                    let _ = sender.send(Err(PeerConnectionError::EventLoopShuttingDown));
-                    return;
-                }
+                let sender = self.abort_if_shutting_down(sender, PeerConnectionError::EventLoopShuttingDown)?;
                 if let hash_map::Entry::Vacant(e) = self.pending_dial.entry(peer_id) {
                     match self.swarm.dial(peer_addr.with(Protocol::P2p(peer_id))) {
                         Ok(()) => {
@@ -599,12 +597,14 @@ impl<P: PublicKey + Send> EventLoop<P> {
                 } else {
                     debug!("Dialing already in progress for peer {peer_id}. Ignoring additional dial attempt.");
                 }
+                Ok(())
             }
             ClientCommand::ResponseToRequest { res, return_chute } => {
                 if let Err(response) = self.swarm.behaviour_mut().json.send_response(return_chute, res) {
                     error!("Failed to send response to request. {response}");
                     // todo: retry logic
                 }
+                Ok(())
             }
             ClientCommand::ProposeChannelRequest { peer_id, data, sender } => {
                 if !self.is_running() {
@@ -612,16 +612,18 @@ impl<P: PublicKey + Send> EventLoop<P> {
                     let reason = RejectReason::NotSent("Event loop is shutting down.".to_string());
                     let rejection = RejectChannelProposal::new(reason, RetryOptions::close_only());
                     let _ = sender.send(ChannelProposalResult::Rejected(rejection));
-                    return;
+                    return Err(());
                 }
                 let id = self.swarm.behaviour_mut().json.send_request(&peer_id, GreaseRequest::ProposeNewChannel(data));
                 self.pending_new_channel_proposals.insert(id, sender);
                 info!("New channel proposal sent to {peer_id}");
+                Ok(())
             }
             ClientCommand::ConnectedPeers { sender } => {
                 debug!("Connected peers requested.");
                 let peers = self.swarm.connected_peers().cloned().collect();
                 let _ = sender.send(peers);
+                Ok(())
             }
             ClientCommand::Shutdown(sender) => {
                 info!("Shutting down event loop.");
@@ -631,42 +633,48 @@ impl<P: PublicKey + Send> EventLoop<P> {
                 for id in connections {
                     self.swarm.close_connection(id);
                 }
+                Ok(())
             }
             // MultiSig wallet prep commands
             ClientCommand::MultiSigInitRequest { peer_id, envelope, sender } => {
-                if !self.is_running() {
-                    info!("Event loop is shutting down. I'm not setting up wallets now.");
-                    let _ = sender.send(Err("Event loop is shutting down.".to_string()));
-                    return;
-                }
+                let sender = self.abort_if_shutting_down(sender, "Event loop is shutting down.".to_string())?;
                 let id = self.swarm.behaviour_mut().json.send_request(&peer_id, GreaseRequest::MsInit(envelope));
                 self.pending_multisig_inits.insert(id, sender);
+                Ok(())
             }
             ClientCommand::MultiSigKeyRequest { peer_id, envelope, sender } => {
-                if !self.is_running() {
-                    info!("Event loop is shutting down. I'm not setting up wallets now.");
-                    let _ = sender.send(Err("Event loop is shutting down.".to_string()));
-                    return;
-                }
+                let sender = self.abort_if_shutting_down(sender, "Event loop is shutting down.".to_string())?;
                 let id = self.swarm.behaviour_mut().json.send_request(&peer_id, GreaseRequest::MsKeyExchange(envelope));
                 self.pending_multisig_keys.insert(id, sender);
+                Ok(())
             }
             ClientCommand::ConfirmMultiSigAddressRequest { peer_id, envelope, sender } => {
-                if !self.is_running() {
-                    info!("Event loop is shutting down. I'm not confirming multisig addresses now.");
-                    let _ = sender.send(Err("Event loop is shutting down.".to_string()));
-                    return;
-                }
+                let sender = self.abort_if_shutting_down(sender, "Event loop is shutting down.".to_string())?;
                 let id =
                     self.swarm.behaviour_mut().json.send_request(&peer_id, GreaseRequest::ConfirmMsAddress(envelope));
                 self.pending_address_confirmations.insert(id, sender);
+                Ok(())
             }
-            ClientCommand::KesReadyNotification { .. } => {}
-            ClientCommand::AckKesReadyNotification { .. } => {}
-            ClientCommand::FundingTxRequestStart { .. } => {}
-            ClientCommand::FundingTxFinalizeRequest { .. } => {}
-            ClientCommand::FundingTxBroadcastNotification { .. } => {}
-            ClientCommand::AckFundingTxBroadcastNotification { .. } => {}
+            ClientCommand::KesReadyNotification { .. } => Err(()),
+            ClientCommand::AckKesReadyNotification { .. } => Err(()),
+            ClientCommand::FundingTxRequestStart { .. } => Err(()),
+            ClientCommand::FundingTxFinalizeRequest { .. } => Err(()),
+            ClientCommand::FundingTxBroadcastNotification { .. } => Err(()),
+            ClientCommand::AckFundingTxBroadcastNotification { .. } => Err(()),
+        }
+    }
+
+    fn abort_if_shutting_down<T, E>(
+        &self,
+        sender: oneshot::Sender<Result<T, E>>,
+        err: E,
+    ) -> Result<oneshot::Sender<Result<T, E>>, ()> {
+        if !self.is_running() {
+            info!("Event loop is shutting down. I'm not accepting any more instructions right now.");
+            let _ = sender.send(Err(err));
+            Err(())
+        } else {
+            Ok(sender)
         }
     }
 }

--- a/p2p/src/network_client.rs
+++ b/p2p/src/network_client.rs
@@ -6,7 +6,9 @@ use futures::channel::{mpsc, oneshot};
 use futures::SinkExt;
 use futures::Stream;
 use libgrease::crypto::traits::PublicKey;
-use libgrease::monero::data_objects::{MoneroAddress, MultiSigInitInfo, MultisigKeyInfo, RequestEnvelope};
+use libgrease::monero::data_objects::{
+    MessageEnvelope, MsKeyAndVssInfo, MultiSigInitInfo, MultisigKeyInfo, WalletConfirmation,
+};
 use libp2p::identity::Keypair;
 use libp2p::multiaddr::Protocol;
 use libp2p::request_response::ResponseChannel;
@@ -118,9 +120,9 @@ impl<P: PublicKey> Client<P> {
         peer_id: PeerId,
         channel: String,
         multisig_init: MultiSigInitInfo,
-    ) -> Result<Result<RequestEnvelope<MultiSigInitInfo>, String>, PeerConnectionError> {
+    ) -> Result<Result<MessageEnvelope<MultiSigInitInfo>, String>, PeerConnectionError> {
         let (sender, receiver) = oneshot::channel();
-        let envelope = RequestEnvelope::new(channel, multisig_init);
+        let envelope = MessageEnvelope::new(channel, multisig_init);
         self.sender.send(ClientCommand::MultiSigInitRequest { peer_id, envelope, sender }).await?;
         let res = receiver.await?;
         Ok(res)
@@ -131,9 +133,9 @@ impl<P: PublicKey> Client<P> {
         peer_id: PeerId,
         channel: String,
         multisig_key: MultisigKeyInfo,
-    ) -> Result<Result<RequestEnvelope<MultisigKeyInfo>, String>, PeerConnectionError> {
+    ) -> Result<Result<MessageEnvelope<MsKeyAndVssInfo>, String>, PeerConnectionError> {
         let (sender, receiver) = oneshot::channel();
-        let envelope = RequestEnvelope::new(channel, multisig_key);
+        let envelope = MessageEnvelope::new(channel, multisig_key);
         self.sender.send(ClientCommand::MultiSigKeyRequest { peer_id, envelope, sender }).await?;
         let res = receiver.await?;
         Ok(res)
@@ -143,10 +145,10 @@ impl<P: PublicKey> Client<P> {
         &mut self,
         peer_id: PeerId,
         channel: String,
-        address: MoneroAddress,
-    ) -> Result<Result<RequestEnvelope<bool>, String>, PeerConnectionError> {
+        confirmation: WalletConfirmation,
+    ) -> Result<Result<MessageEnvelope<bool>, String>, PeerConnectionError> {
         let (sender, receiver) = oneshot::channel();
-        let envelope = RequestEnvelope::new(channel, address);
+        let envelope = MessageEnvelope::new(channel, confirmation);
         self.sender.send(ClientCommand::ConfirmMultiSigAddressRequest { peer_id, envelope, sender }).await?;
         let res = receiver.await?;
         Ok(res)

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -1,4 +1,4 @@
-use crate::errors::{PaymentChannelError, PeerConnectionError};
+use crate::errors::{ChannelServerError, PaymentChannelError, PeerConnectionError};
 use crate::message_types::{
     ChannelProposalResult, NewChannelProposal, RejectChannelProposal, RejectReason, RetryOptions,
 };
@@ -11,16 +11,22 @@ use futures::future::join;
 use futures::StreamExt;
 use libgrease::channel_id::ChannelId;
 use libgrease::crypto::traits::PublicKey;
-use libgrease::kes::KeyEscrowService;
-use libgrease::monero::data_objects::RequestEnvelope;
+use libgrease::kes::{KesInitializationRecord, KeyEscrowService, PartialEncryptedKey};
+use libgrease::monero::data_objects::{
+    MessageEnvelope, MsKeyAndVssInfo, MultiSigInitInfo, MultisigKeyInfo, WalletConfirmation,
+};
 use libgrease::monero::{MultiSigWallet, WalletState};
-use libgrease::payment_channel::{ActivePaymentChannel};
+use libgrease::payment_channel::ActivePaymentChannel;
 use libgrease::state_machine::error::InvalidProposal;
-use libgrease::state_machine::{ChannelLifeCycle, LifecycleStage, NewChannelBuilder};
+use libgrease::state_machine::{
+    ChannelInitSecrets, ChannelLifeCycle, ChannelMetadata, LifecycleStage, NewChannelBuilder, VssOutput,
+};
 use libp2p::request_response::ResponseChannel;
 use libp2p::Multiaddr;
 use log::*;
+use monero::Network;
 use std::collections::VecDeque;
+use std::fmt::{Display, Formatter};
 use std::future;
 use std::path::Path;
 use std::sync::Arc;
@@ -28,21 +34,6 @@ use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 use tokio::task::JoinHandle;
 
 pub type WritableState<P, C, W, KES> = OwnedRwLockWriteGuard<PaymentChannel<P, C, W, KES>>;
-
-macro_rules! abort {
-    ($channel_name:expr, $msg:expr) => {{
-        use crate::server::NextAction;
-        warn!("{}", $msg);
-        NextAction::Abort {
-            channel_name: $channel_name.to_string(),
-            reason: format!("Aborting {}. Reason: {}", $channel_name, $msg),
-        }}
-    };
-    ($channel_name:expr, $fmt:literal, $($args:tt)*) => {{
-        let msg = format!($fmt, $($args)*);
-        abort!($channel_name, msg)
-    }};
-}
 
 pub struct NetworkServer<P, C, W, KES, D, K>
 where
@@ -91,7 +82,7 @@ where
                     }
                 }
                 // Carry out any pending tasks
-                inner_clone.clear_todo_list().await;
+                inner_clone.work_through_todo_list().await;
             }
         });
         Ok(Self { id, inner, event_loop_handle, event_handler_handle })
@@ -245,7 +236,7 @@ where
     }
 
     async fn add_todo_list_item(&self, item: TodoListItem) {
-        debug!("🖥️  Adding item to todo list: {item:?}");
+        debug!("🖥️  Adding item to todo list: {item}");
         let mut write_lock = self.todo_list.write().await;
         write_lock.push_back(item);
         drop(write_lock);
@@ -265,24 +256,20 @@ where
         next_item
     }
 
-    async fn clear_todo_list(&self) {
+    async fn work_through_todo_list(&self) {
         while let Some(next_item) = self.get_next_todo_list_item().await {
+            let channel_name = next_item.channel_name();
             let next = match next_item {
-                TodoListItem::CreateMultiSigWallet { channel_name } => self.prepare_multisig_wallet(channel_name).await,
-                TodoListItem::CreateNewKes { channel_name } => self.create_kes(channel_name).await,
+                TodoListItem::CreateMultiSigWallet { channel_name } => self.build_biparty_channel(channel_name).await,
                 TodoListItem::ConstructFundingTransaction { channel_name } => {
-                    self.create_funding_transaction(channel_name).await
+                    self.create_funding_transaction(&channel_name).await
                 }
                 TodoListItem::CloseChannel { channel_name, reason } => self.close_channel(channel_name, reason).await,
             };
-            match next {
-                NextAction::Continue => trace!("🖥️  Todo item completed successfully"),
-                NextAction::Ignore => trace!("🖥️  Todo item errored out, but we're ignoring it"),
-                NextAction::Abort { channel_name, reason } => {
-                    debug!("🖥️  Aborting channel: {reason}");
-                    let item = TodoListItem::CloseChannel { channel_name, reason };
-                    self.add_todo_list_item(item).await;
-                }
+            if let Err(err) = next {
+                debug!("🖥️  Aborting channel: {err}");
+                let item = TodoListItem::CloseChannel { channel_name, reason: err.to_string() };
+                self.add_todo_list_item(item).await;
             }
         }
     }
@@ -304,13 +291,7 @@ where
     ) {
         let name = request.channel_name();
         let response = if self.channels.exists(&name).await {
-            match self.channels.checkout(&name).await {
-                Some(channel) => self.handle_grease_request_for_existing_channel(request, channel).await,
-                None => {
-                    warn!("🖥️  Channel exists, but we could not get a write lock: {name}");
-                    GreaseResponse::Error("Could not get write lock".into())
-                }
-            }
+            self.handle_request_for_existing_channel(request).await
         } else {
             // Channel doesn't exist, so this must be a new proposal, or we can´t do anything about it
             match &request {
@@ -327,84 +308,132 @@ where
         }
     }
 
-    async fn handle_grease_request_for_existing_channel(
-        &self,
-        request: GreaseRequest<P>,
-        mut channel: OwnedRwLockWriteGuard<PaymentChannel<P, C, W, KES>>,
-    ) -> GreaseResponse<P> {
+    async fn handle_request_for_existing_channel(&self, request: GreaseRequest<P>) -> GreaseResponse<P> {
         // Note: The channel name has already been checked against the incoming message.
         match request {
             GreaseRequest::ProposeNewChannel(_) => {
-                GreaseResponse::Error("Cannot create a new channel. Channel already exists.".into())
+                GreaseResponse::Error("Cannot create a new channel. Channel exists.".into())
             }
-            GreaseRequest::MsInit(envelope) => {
-                trace!("🖥️  Multisig Init request received");
-                let (channel_name, peer_info) = envelope.open();
-                if let Err(err) = channel.wallet_preparation(|wallet_state| wallet_state.prepare_multisig()).await {
-                    warn!("🖥️  Error preparing multisig wallet: {err}");
-                    return GreaseResponse::MsInit(Err("Customer could not create wallet".into()));
-                }
-                trace!("🖥️  Customer: Multisig wallet prepared");
-                let Some(my_info) = channel.wallet_state().ok().and_then(|s| s.init_info().cloned()) else {
-                    return GreaseResponse::MsInit(Err("Customer could not generate initialization info".into()));
-                };
-                // Add customer's peer info and make multisig wallet
-                if let Err(err) =
-                    channel.wallet_preparation(|wallet_state| Box::pin(wallet_state.make_multisig(peer_info))).await
-                {
-                    warn!("🖥️  Error making multisig wallet: {err}");
-                    return GreaseResponse::MsInit(Err("Customer could not create wallet".into()));
-                }
-                trace!("🖥️  Customer: Multisig wallet made. Returning init info to merchant");
-                let envelope = RequestEnvelope::new(channel_name, my_info);
-                GreaseResponse::MsInit(Ok(envelope))
-            }
+            GreaseRequest::MsInit(envelope) => self.customer_wallet_init(envelope).await.unwrap_or_else(|early| early),
             GreaseRequest::MsKeyExchange(envelope) => {
-                trace!("🖥️  Multisig Key Exchange request received");
-                let (channel_name, peer_key_info) = envelope.open();
-                if let Err(err) = channel
-                    .wallet_preparation(|wallet_state| Box::pin(wallet_state.import_multisig_keys(peer_key_info)))
-                    .await
-                {
-                    warn!("Error importing multisig keys: {err}");
-                    return GreaseResponse::MsKeyExchange(Err("Customer could not import keys".into()));
-                }
-                trace!("🖥️  Customer: Peer multisig keys imported.");
-                let Some(my_key_info) = channel.wallet_state().ok().and_then(|s| s.multisig_keys().cloned()) else {
-                    return GreaseResponse::MsKeyExchange(Err("Customer could not generate key info".into()));
-                };
-                trace!("🖥️  Customer: Multisig keys retrieved. Sending them onto merchant");
-                let envelope = RequestEnvelope::new(channel_name, my_key_info);
-                GreaseResponse::MsKeyExchange(Ok(envelope))
+                self.customer_add_ms_key_and_split_secrets(envelope).await.unwrap_or_else(|early| early)
             }
             GreaseRequest::ConfirmMsAddress(envelope) => {
                 trace!("🖥️  Confirm multisig address request received");
-                let (channel_name, address) = envelope.open();
-                let addr_str = address.to_string();
-                let result = match channel.wallet_state() {
-                    Ok(state) => match state.get_address().await {
-                        Some(my_address) if my_address == address => {
-                            info!("🖥️  Multisig wallet created with address {addr_str}");
-                            true
-                        }
-                        Some(my_address) if my_address != address => {
-                            warn!("🖥️  The merchant's address {addr_str} does not match ours {my_address}");
-                            false
-                        }
-                        _ => false,
-                    },
-                    Err(_) => false,
-                };
-                if !result {
-                    warn!("🖥️  Could not confirm multisig address");
-                }
-                let envelope = RequestEnvelope::new(channel_name, result);
+                let (channel_name, confirmation) = envelope.open();
+                let response = self.compare_address_and_save_vss(&channel_name, confirmation).await.unwrap_or(false);
+                let envelope = MessageEnvelope::new(channel_name, response);
                 GreaseResponse::ConfirmMsAddress(envelope)
             }
         }
     }
+    //----------------------------   State machine handling functions (Customer)   ----------------------------------//
 
-    //---------------------------------------- State machine handling functions --------------------------------------//
+    async fn customer_wallet_init(
+        &self,
+        envelope: MessageEnvelope<MultiSigInitInfo>,
+    ) -> Result<GreaseResponse<P>, GreaseResponse<P>> {
+        trace!("🖥️  Customer: Multisig Init request received");
+        let (channel_name, merchant_info) = envelope.open();
+
+        // fetch init info for merchant
+        let mut channel = self.channels.checkout(&channel_name).await.ok_or_else(|| GreaseResponse::ChannelNotFound)?;
+        channel.wallet_preparation(|wallet_state| wallet_state.prepare_multisig()).await.map_err(|err| {
+            warn!("🖥️  Error preparing multisig wallet: {err}");
+            GreaseResponse::MsInit(Err("Customer could not create wallet".into()))
+        })?;
+        trace!("🖥️  Customer: Multisig wallet prepared. Returning key info to merchant.");
+        let customer_info = channel
+            .wallet_state()
+            .map_err(|err| {
+                warn!("🖥️  Customer: Error getting multisig wallet state: {err}");
+                GreaseResponse::MsInit(Err("Customer could not generate initialization info".into()))
+            })
+            .and_then(|state| {
+                state.init_info().ok_or_else(|| {
+                    warn!("🖥️  Customer: Wallet is not is the 'Prepared' state");
+                    GreaseResponse::MsInit(Err(
+                        "Customer could not generate initialization info. Wallet state was incorrect".into(),
+                    ))
+                })
+            })?
+            .clone();
+
+        // Add customer's peer info and make multisig wallet
+        channel.wallet_preparation(|wallet_state| Box::pin(wallet_state.make_multisig(merchant_info))).await.map_err(
+            |err| {
+                warn!("🖥️  Error making multisig wallet: {err}");
+                return GreaseResponse::MsInit(Err("Customer could not create wallet".into()));
+            },
+        )?;
+        drop(channel);
+        trace!("🖥️  Customer: Multisig wallet made. Returning init info to merchant");
+        let envelope = MessageEnvelope::new(channel_name, customer_info);
+        Ok(GreaseResponse::MsInit(Ok(envelope)))
+    }
+
+    async fn customer_add_ms_key_and_split_secrets(
+        &self,
+        envelope: MessageEnvelope<MultisigKeyInfo>,
+    ) -> Result<GreaseResponse<P>, GreaseResponse<P>> {
+        trace!("🖥️  Multisig Key Exchange request received");
+        let (name, peer_key_info) = envelope.open();
+
+        // import the multisig key into our wallet. Prep step 2
+        let mut channel = self.channels.checkout(&name).await.ok_or_else(|| GreaseResponse::ChannelNotFound)?;
+        channel
+            .wallet_preparation(|wallet_state| Box::pin(wallet_state.import_multisig_keys(peer_key_info)))
+            .await
+            .map_err(|err| {
+                warn!("Error importing multisig keys: {err}");
+                return GreaseResponse::MsKeyExchange(Err("Customer could not import keys".into()));
+            })?;
+        trace!("🖥️  Customer: Peer multisig keys imported.");
+
+        // Generate the VSS info that we return to the merchant
+        let secrets = self.get_vss_info(&name).await.map_err(|err| {
+            warn!("🖥️  Error getting VSS info: {err}");
+            GreaseResponse::MsKeyExchange(Err("Customer could not get VSS info".into()))
+        })?;
+        let shards_for_merchant = self.delegate.split_and_encrypt_keys(secrets).await.map_err(|err| {
+            warn!("🖥️  Error splitting and encrypting keys: {err}");
+            GreaseResponse::MsKeyExchange(Err("Customer could not split and encrypt keys".into()))
+        })?;
+
+        // Get the Multisig key info and save the shards we've just calculated.
+        let mut channel = self.channels.checkout(&name).await.ok_or_else(|| GreaseResponse::ChannelNotFound)?;
+        let multisig_key = channel
+            .wallet_state()
+            .unwrap()
+            .multisig_keys()
+            .cloned()
+            .ok_or_else(|| GreaseResponse::MsKeyExchange(Err("Customer could not generate MultisigKey".into())))?;
+        channel.update_wallet_state(|state| state.save_peer_shards(shards_for_merchant.clone()));
+
+        let response = MsKeyAndVssInfo { multisig_key, shards_for_merchant: shards_for_merchant };
+        trace!("🖥️ Customer: VSS complete. Responding to merchant.");
+        let envelope = MessageEnvelope::new(name, response);
+        Ok(GreaseResponse::MsKeyExchange(Ok(envelope)))
+    }
+
+    /// The customer checks that the wallet address they created matches the one in the confirmation record.
+    /// If it does, it saves the split secrets, and returns `true` to the merchant.
+    ///
+    /// Otherwise, it returns `false` and the merchant will close the channel.
+    async fn compare_address_and_save_vss(&self, channel: &str, confirmation: WalletConfirmation) -> Option<bool> {
+        let mut channel = self.channels.checkout(channel).await?;
+        let address = channel.wallet_state().ok()?.get_address().await?;
+        let addresses_match = address == confirmation.address;
+        if addresses_match {
+            channel.update_wallet_state(|state| state.save_my_shards(confirmation.merchant_vss_info));
+            debug!("🖥️  Customer: Address confirmed. Merchant split secrets for KES and Merchant saved.");
+        } else {
+            warn!("🖥️  Customer: The derived address for the merchant's wallet doesn't match ours. This channel will be closed.");
+        }
+        Some(addresses_match)
+    }
+
+    //------------------------------ State machine handling functions (Merchant) ------------------------------------//
 
     /// Handle an incoming request to open a payment channel.
     async fn handle_open_channel_request(&self, data: &NewChannelProposal<P>) -> GreaseResponse<P> {
@@ -430,130 +459,234 @@ where
         })?;
         let ack = ChannelProposalResult::accept(data.clone());
         // Queue up the tasks to complete next in order to establish the channel
-        let channel_name = channel.name();
-        let todo_list = [
-            TodoListItem::CreateMultiSigWallet { channel_name: channel_name.clone() },
-            TodoListItem::CreateNewKes { channel_name: channel_name.clone() },
-            TodoListItem::ConstructFundingTransaction { channel_name: channel_name.clone() },
-            // When the Funding tx is broadcast, it'll get picked up by the event loop and the state will move to
-            // Open automatically.
-        ];
-        self.add_todo_list_items(todo_list).await;
+        // We don't queue up the KES yet, because we need the partial encrypted key info, which only becomes available
+        // upon wallet setup completion.
+        let item = TodoListItem::CreateMultiSigWallet { channel_name: channel.name() };
+        self.add_todo_list_item(item).await;
         self.channels.add(channel).await;
 
         Ok(GreaseResponse::ChannelProposalResult(ack))
     }
 
-    async fn close_channel(&self, channel_name: String, reason: String) -> NextAction {
+    async fn close_channel(&self, channel_name: String, reason: String) -> Result<(), ChannelServerError> {
         info!("🖥️  Closing channel {channel_name}. {reason}");
-        error!("🖥️  TODO!");
-        NextAction::Continue
+        // TODO - complete this
+        Ok(())
     }
 
-    /// As a merchant, fetch the multisig initialization data from the wallet.
-    ///Once received, pass the information to the peer over the wire and wait.
-    async fn prepare_multisig_wallet(&self, channel_name: String) -> NextAction {
-        let next = self.prepare_multisig_wallet_wrapped(channel_name).await.unwrap_or_else(|next_action| next_action);
-        match next {
-            NextAction::Continue => {
-                info!("🖥️  Multisig wallet prepared successfully");
+    /// Returns the channel metadata for the given channel name, if the current lifecycle state has the information
+    /// available.
+    async fn get_channel_metadata(&self, channel_name: &str) -> Option<ChannelMetadata<P>> {
+        let lock = self.channels.try_peek(channel_name).await?;
+        lock.state().channel_info().cloned()
+    }
+
+    /// The merchant takes the lead in establishing a new channel. After going through the multisig wallet creation
+    /// process, he must establish the KES and allow the customer to verify it. Finally, the funding transaction(s)
+    /// must be broadcast and verified, at which point the channel is open.
+    async fn build_biparty_channel(&self, channel_name: String) -> Result<(), ChannelServerError> {
+        self.prepare_multisig_wallet(&channel_name).await?;
+        info!(" 🖥️  New Multisig wallet for {channel_name} created.");
+        self.establish_kes(&channel_name).await?;
+        info!(" 🖥️  KES established for {channel_name}.");
+        self.create_funding_transaction(&channel_name).await?;
+        info!(" 🖥️  Funding transaction created for {channel_name}.");
+        Ok(())
+    }
+
+    async fn establish_kes(&self, channel_name: &str) -> Result<(), ChannelServerError> {
+        let channel = self.channels.try_peek(channel_name).await.ok_or(ChannelServerError::ChannelNotFound)?;
+        let kes_info =
+            channel.state().kes_info().ok_or(ChannelServerError::InvalidState("KES info not available".to_string()))?;
+        drop(channel);
+        let result = self.delegate.initialize_kes(kes_info).await.map_err(|err| ChannelServerError::KesError(err))?;
+        let mut channel = self.channels.checkout(channel_name).await.ok_or(ChannelServerError::ChannelNotFound)?;
+        channel.save_kes_result(result)?;
+        Ok(())
+    }
+
+    async fn create_funding_transaction(&self, channel_name: &str) -> Result<(), ChannelServerError> {
+        Ok(())
+    }
+
+    async fn create_kes(&self, channel_name: String, init: KesInitializationRecord) -> NextAction {
+        debug!("🖥️  Initiating new KES for channel {channel_name}");
+        match self.delegate.initialize_kes(init).await {
+            Ok(kes_result) => {
+                info!("🖥️  KES initialized successfully");
                 NextAction::Continue
             }
-            NextAction::Ignore => {
-                info!("🖥️  Multisig wallet preparation failed, but we're ignoring it");
-                NextAction::Ignore
-            }
-            NextAction::Abort { channel_name, reason } => {
-                warn!("🖥️  Multisig wallet preparation failed: {reason}");
-                NextAction::Abort { channel_name, reason }
+            Err(err) => {
+                warn!("🖥️  KES initialization failed: {err}");
+                NextAction::Abort { channel_name, reason: "KES initialization failed".to_string() }
             }
         }
     }
 
-    async fn create_funding_transaction(&self, channel_name: String) -> NextAction {
-        debug!("🖥️  Creating funding transaction for channel {channel_name}");
-        NextAction::Continue
-    }
-
-    async fn create_kes(&self, channel_name: String) -> NextAction {
-        debug!("🖥️  Creating KES for channel {channel_name}");
-        NextAction::Continue
-    }
-
-    // This function is the actual implementation of the multisig wallet preparation. It returns result for ergonomics
-    // so that abort! macros can return early.
-    async fn prepare_multisig_wallet_wrapped(&self, channel_name: String) -> Result<NextAction, NextAction> {
+    /// Creates a new multisig wallet and prepares it for use.
+    ///
+    /// On successful return, the wallet is in the `WalletCreated` state and is ready to receive funds.
+    /// The VSS record has also been sent to the customer.
+    async fn prepare_multisig_wallet(&self, channel_name: &str) -> Result<(), ChannelServerError> {
         // Pre creation sanity checks and get the required channel info from the state machine
-        let (channel_id, peer) = self.pre_wallet_checks(&channel_name).await?;
+        let (network, channel_id, peer) = self.pre_wallet_checks(&channel_name).await?;
+        let (mut wallet_state, info) = Self::init_new_wallet(network, channel_name, &channel_id).await?;
+        let mut client = self.network_client.clone();
+        wallet_state = Self::share_init_info_with_peer(channel_name, &peer, wallet_state, &info, &mut client).await?;
+        wallet_state = Self::share_key_info_with_peer(channel_name, &peer, &mut client, wallet_state).await?;
+        wallet_state =
+            Self::confirm_wallet_address_and_share_vss(&self, channel_name, peer, wallet_state, &mut client).await?;
+        trace!("🖥️  Merchant: Address confirmed. Accepting new wallet and moving to next state");
+        let mut channel = self.channels.checkout(&channel_name).await.ok_or(ChannelServerError::ChannelNotFound)?;
+        // Inject this wallet state machine
+        channel.wallet_preparation(|_state| future::ready(wallet_state)).await?;
+        channel.accept_new_wallet().await?;
+        Ok(())
+    }
 
-        // Step 1 - Prepare multisig
-        let wallet = W::new(&channel_id).map_err(|e| abort!(&channel_name, "Error creating wallet: {}", e))?;
-        let mut wallet_state = WalletState::new(wallet);
+    /// The merchant creates a new multisig wallet and prepares it for use.
+    async fn init_new_wallet(
+        network: Network,
+        channel_name: &str,
+        channel_id: &ChannelId,
+    ) -> Result<(WalletState<W>, MultiSigInitInfo), ChannelServerError> {
+        let wallet = W::new(&channel_id)?;
+        let mut wallet_state = WalletState::new(network, wallet);
         trace!("🖥️  Merchant: Preparing multisig wallet");
         wallet_state = wallet_state.prepare_multisig().await;
-        let info = wallet_state.init_info().ok_or_else(|| abort!(&channel_name, "Wallet state is not prepared"))?;
+        let info = wallet_state
+            .init_info()
+            .ok_or_else(|| {
+                ChannelServerError::InvalidState(format!("Wallet state for channel {channel_name} is not 'Prepared'"))
+            })?
+            .clone();
+        Ok((wallet_state, info))
+    }
 
-        // Step 2 - Share info with peer
-        let mut client = self.network_client.clone();
+    /// The merchant shares the Monero multisig wallet initialization info (step 1) with the customer, expecting the
+    /// customer to respond with their own init info.
+    async fn share_init_info_with_peer(
+        channel_name: &str,
+        peer: &ContactInfo,
+        wallet_state: WalletState<W>,
+        info: &MultiSigInitInfo,
+        client: &mut Client<P>,
+    ) -> Result<WalletState<W>, ChannelServerError> {
         trace!("🖥️  Sending init info to customer");
-        let (peer_channel, peer_info) =
-            match client.send_multisig_init(peer.peer_id, channel_name.clone(), info.clone()).await {
-                Ok(Ok(envelope)) => Ok(envelope.open()),
-                Ok(Err(e)) => Err(abort!(&channel_name, "Peer did not return multisig init data: {}", e)),
-                Err(e) => Err(abort!(&channel_name, "Error sending multisig init data to peer: {}", e)),
-            }?;
+        let (peer_channel, peer_info) = client
+            .send_multisig_init(peer.peer_id, channel_name.to_owned(), info.clone())
+            .await?
+            .map_err(|s| ChannelServerError::PeerCommsError(s))?
+            .open();
+
         if peer_channel != channel_name {
-            return Err(abort!(&channel_name, "Peer returned a different channel name: {peer_channel}"));
+            return Err(ChannelServerError::PeerCommsError(format!(
+                "Mismatched channel names. Expected {channel_name}, Received {peer_channel}"
+            )));
         }
         trace!("🖥️  Merchant: Received multisig init data from customer. Calling make_multisig");
-        wallet_state = wallet_state.make_multisig(peer_info).await;
-        // Step 3 - Send key info to peer
-        let key =
-            wallet_state.multisig_keys().ok_or_else(|| abort!(&channel_name, "Wallet state is not prepared"))?.clone();
+        Ok(wallet_state.make_multisig(peer_info).await)
+    }
+
+    /// The merchant shares the Monero multisig wallet key info (step 2) with the customer, expecting the customer to
+    /// respond with their own key info PLUS their VSS info in a `MsKeyAndVssInfo` envelope.
+    async fn share_key_info_with_peer(
+        channel_name: &str,
+        peer: &ContactInfo,
+        client: &mut Client<P>,
+        mut wallet_state: WalletState<W>,
+    ) -> Result<WalletState<W>, ChannelServerError> {
+        let key = wallet_state
+            .multisig_keys()
+            .ok_or_else(|| {
+                ChannelServerError::InvalidState(format!("Channel {channel_name}'s wallet state is not 'Prepared'"))
+            })?
+            .clone();
+
         trace!("🖥️  Merchant: Sending multisig partial key to customer");
-        let (peer_channel, peer_key) = match client.send_multisig_key(peer.peer_id, channel_name.clone(), key).await {
-            Ok(Ok(envelope)) => Ok(envelope.open()),
-            Ok(Err(e)) => Err(abort!(&channel_name, "Peer did not return multisig key data: {}", e)),
-            Err(e) => Err(abort!(&channel_name, "Error sending multisig key data to peer: {}", e)),
-        }?;
+        let (peer_channel, customer_keys) = client
+            .send_multisig_key(peer.peer_id, channel_name.to_owned(), key)
+            .await?
+            .map_err(|s| ChannelServerError::PeerCommsError(s))?
+            .open();
+
         if peer_channel != channel_name {
-            return Err(abort!(&channel_name, "Peer returned a different channel name: {peer_channel}"));
+            return Err(ChannelServerError::PeerCommsError(format!(
+                "Mismatched channel names. Expected {channel_name}, Received {peer_channel}"
+            )));
         }
-        // Step 4 - Confirm address
         trace!("🖥️  Merchant: Received multisig key data from customer. Calling import_multisig_keys");
-        wallet_state = wallet_state.import_multisig_keys(peer_key).await;
+        wallet_state = wallet_state.import_multisig_keys(customer_keys.multisig_key).await;
+        wallet_state = wallet_state.save_my_shards(customer_keys.shards_for_merchant);
+        Ok(wallet_state)
+    }
+
+    /// The merchant sends the derived multisig wallet address to the customer and waits for confirmation (i.e. that
+    /// the customer was able to derive the same address).
+    /// The merchant must also generate their VSS data and include it in the request.
+    async fn confirm_wallet_address_and_share_vss(
+        &self,
+        channel_name: &str,
+        peer: ContactInfo,
+        wallet_state: WalletState<W>,
+        client: &mut Client<P>,
+    ) -> Result<WalletState<W>, ChannelServerError> {
         trace!("🖥️  Merchant: Fetching address");
-        let address =
-            wallet_state.get_address().await.ok_or_else(|| abort!(&channel_name, "Wallet state is not prepared"))?;
-        trace!("🖥️  Merchant: Sending address {} to customer", address.to_string());
-        let (peer_channel, addresses_match) =
-            match client.confirm_multisig_address(peer.peer_id, channel_name.clone(), address).await {
-                Ok(Ok(envelope)) => Ok(envelope.open()),
-                Ok(Err(e)) => Err(abort!(&channel_name, "Error confirming multisig address: {}", e)),
-                Err(e) => Err(abort!(&channel_name, "Error sending multisig address data to peer: {}", e)),
-            }?;
+        let address = wallet_state.get_address().await.ok_or_else(|| {
+            ChannelServerError::InvalidState(format!("Channel {channel_name}'s wallet state is not 'Prepared'"))
+        })?;
+        let secrets = self.get_vss_info(&channel_name).await?;
+        let shards_for_customer = self.create_vss(secrets).await?;
+
+        let mut channel = self.channels.checkout(&channel_name).await.ok_or(ChannelServerError::ChannelNotFound)?;
+        channel.update_wallet_state(|state| state.save_peer_shards(shards_for_customer.clone()));
+        drop(channel);
+
+        trace!(
+            "🖥️  Merchant: Sending wallet confirmation for {} to customer",
+            address.to_string()
+        );
+        let confirmation = WalletConfirmation { address, merchant_vss_info: shards_for_customer };
+        let (peer_channel, addresses_match) = client
+            .confirm_multisig_address(peer.peer_id, channel_name.to_owned(), confirmation)
+            .await?
+            .map_err(|s| ChannelServerError::PeerCommsError(s))?
+            .open();
         if peer_channel != channel_name {
-            return Err(abort!(&channel_name, "Peer returned a different channel name: {peer_channel}"));
+            return Err(ChannelServerError::PeerCommsError(format!(
+                "Mismatched channel names. Expected {channel_name}, Received {peer_channel}"
+            )));
         }
         if !addresses_match {
-            return Err(abort!(&channel_name, "Peer rejected the monero wallet address"));
+            return Err(ChannelServerError::PeerCommsError(format!(
+                "Peer rejected the monero wallet address for {channel_name}"
+            )));
         }
-        trace!("🖥️  Merchant: Address confirmed. Accepting new wallet and moving to next state");
-        match self.channels.checkout(&channel_name).await {
-            Some(mut channel) => {
-                // Inject this wallet state machine
-                channel
-                    .wallet_preparation(|_state| future::ready(wallet_state))
-                    .await
-                    .map_err(|e| abort!(channel_name, "Error setting wallet state: {}", e))?;
-                channel
-                    .accept_new_wallet()
-                    .await
-                    .map(|_| NextAction::Continue)
-                    .map_err(|e| abort!(channel_name, "Error accepting new wallet: {}", e))
+        Ok(wallet_state)
+    }
+
+    // ------------------------------   State machine handling functions (Common)   ----------------------------------//
+
+    async fn get_vss_info(&self, channel_name: &str) -> Result<ChannelInitSecrets<P>, ChannelServerError> {
+        let channel = self.channels.try_peek(&channel_name).await.ok_or(ChannelServerError::ChannelNotFound)?;
+        let vss_info = match channel.state() {
+            ChannelLifeCycle::WalletCreated(state) => state.vss_info(),
+            _ => {
+                return Err(ChannelServerError::InvalidState(format!(
+                    "Channel {channel_name} is not in the WalletCreated state"
+                )))
             }
-            None => Err(abort!(&channel_name, "So close! Channel not found")),
-        }
+        }?;
+        Ok(vss_info)
+    }
+
+    async fn create_vss(&self, vss_info: ChannelInitSecrets<P>) -> Result<VssOutput, ChannelServerError> {
+        let vss_info = self.delegate.create_vss(vss_info).await.map_err(|err| {
+            warn!("🖥️  VSS creation failed: {}", err.reason);
+            ChannelServerError::VssFailure(err.reason)
+        })?;
+        debug!("🖥️  VSS created successfully");
+        Ok(vss_info)
     }
 
     //------------------------------------------- Minor helper functions ---------------------------------------------//
@@ -609,27 +742,33 @@ where
     // 1. The channel exists
     // 2. The channel is in the Establishing state
     // 3. The role of this side of the channel is Merchant
-    async fn pre_wallet_checks(&self, channel_name: &str) -> Result<(ChannelId, ContactInfo), NextAction> {
+    async fn pre_wallet_checks(
+        &self,
+        channel_name: &str,
+    ) -> Result<(Network, ChannelId, ContactInfo), ChannelServerError> {
         trace!("Peeking at channel {channel_name}");
         match self.channels.try_peek(channel_name).await {
             Some(channel) => match channel.state() {
                 ChannelLifeCycle::Establishing(state) => {
                     let role = state.channel_info.role;
                     let state_needed = (
+                        state.channel_info.network,
                         state.channel_info.channel_id.clone(),
                         channel.peer_info(),
                     );
                     drop(channel);
                     if role.is_customer() {
                         error!("🖥️  Wallet setup must start from merchant side. Channel {channel_name} is not a merchant channel");
-                        Err(abort!(&channel_name, "Channel is not a merchant channel"))
+                        Err(ChannelServerError::NotMerchantRole)
                     } else {
                         Ok(state_needed)
                     }
                 }
-                _ => Err(abort!(&channel_name, "Channel is not in the Establishing state")),
+                _ => Err(ChannelServerError::InvalidState(format!(
+                    "Channel {channel_name} is not in the Establishing state"
+                ))),
             },
-            None => Err(abort!(&channel_name, "Channel not found")),
+            None => Err(ChannelServerError::ChannelNotFound),
         }
     }
 }
@@ -638,9 +777,6 @@ where
 pub enum TodoListItem {
     /// Send the multisig wallet init data to the peer for channel `channel_name`
     CreateMultiSigWallet {
-        channel_name: String,
-    },
-    CreateNewKes {
         channel_name: String,
     },
     ConstructFundingTransaction {
@@ -652,11 +788,33 @@ pub enum TodoListItem {
     },
 }
 
+impl Display for TodoListItem {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TodoListItem::CreateMultiSigWallet { channel_name } => {
+                write!(f, "Create multisig wallet for {channel_name}")
+            }
+            TodoListItem::ConstructFundingTransaction { channel_name } => {
+                write!(f, "Construct funding transaction for {channel_name}")
+            }
+            TodoListItem::CloseChannel { channel_name, reason } => write!(f, "Close channel {channel_name}: {reason}"),
+        }
+    }
+}
+
+impl TodoListItem {
+    pub fn channel_name(&self) -> String {
+        match self {
+            TodoListItem::CreateMultiSigWallet { channel_name } => channel_name.clone(),
+            TodoListItem::ConstructFundingTransaction { channel_name } => channel_name.clone(),
+            TodoListItem::CloseChannel { channel_name, .. } => channel_name.clone(),
+        }
+    }
+}
+
 pub enum NextAction {
     /// Task completed successfully. Continue as normal
     Continue,
-    /// There was an error, but we can continue
-    Ignore,
     /// Close the channel with reason given
     Abort { channel_name: String, reason: String },
 }


### PR DESCRIPTION
This PR makes some major changes including:

== Correct use and context of secrets.

The secret in channel info is really the decryption key for the spend key shards that are obtained after a successful dispute. It is renames decryption_key accrodingly.

The spend key for the commitment transaction is split twice:
- once to create the 2-of-2 multisig wallet
- and those splits are split _again_, encrypted, and handed to the peer and KES. The latter keys are now called shards, with naming reflecting the intended user of the keys. At the end of the day, you need your half of the 2-of-2 spend key (1/2 a key), your shard (1/4 key) and a shard from the KES (1/4 key).

== Multisig wallet state machine

This is refactored to more accurately match the RPC steps that would be needed to create the wallet. In particular, the KeyPair is known very early on in the process, so the WalletState machine reflects this now.

== Other notes

Refactor channel lifecycle and wallet preparation logic

- **Delegate Enhancements**:
  - Updated `DummyDelegate` to include a `kes` field and implemented `Default`.
  - Added methods to `DummyDelegate` for creating VSS, accessing KES, and splitting/encrypting keys.

- **State Machine Updates**:
  - Introduced `ChannelMetadata` to encapsulate channel-related metadata.
  - Replaced individual fields in `NewChannelState` with `ChannelMetadata`.
  - Updated methods in `NewChannelState` to use `ChannelMetadata` for consistency.

- **Error Handling Improvements**:
  - Added `ChannelServerError` and `VssError` enums for more granular error reporting.
  - Replaced `abort!` macro with structured error handling in server logic.

- **P2P Enhancements**:
  - Refactored `EventLoop` to centralize shutdown checks with `abort_if_shutting_down`.
  - Simplified `handle_request_for_existing_channel` by delegating specific request handling to dedicated methods.
  - Added detailed methods for customer and merchant workflows:
    - Customer: `customer_wallet_init`, `customer_add_ms_key_and_split_secrets`, `compare_address_and_save_vss`.
    - Merchant: `prepare_multisig_wallet`, `share_init_info_with_peer`, `share_key_info_with_peer`, `confirm_wallet_address_and_share_vss`.

- **Lifecycle Enhancements**:
  - Added `save_kes_result` to store KES initialization results in the channel lifecycle.
  - Introduced `update_wallet_state` for synchronous wallet state updates.

- **Todo List Improvements**:
  - Renamed `clear_todo_list` to `work_through_todo_list` for clarity.
  - Added `Display` implementation for `TodoListItem` to improve logging.

- **Message Handling**:
  - Replaced `RequestEnvelope` with `MessageEnvelope` for consistency in P2P message types.
  - Updated related structs and methods to use `MessageEnvelope`.

- **Miscellaneous**:
  - Added `serde` feature to `monero` dependency in `Cargo.toml`.
  - Improved logging messages for better traceability.
  - Removed unused `CreateNewKes` todo list item.

This refactor improves modularity, error handling, and clarity in the channel lifecycle and wallet preparation processes.