### PR TITLE
feat: funding transaction events

### DIFF
--- a/libgrease/src/amount.rs
+++ b/libgrease/src/amount.rs
@@ -12,6 +12,11 @@ pub struct MoneroAmount {
 }
 
 impl MoneroAmount {
+    /// Returns true if the amount is zero.
+    pub(crate) fn is_zero(&self) -> bool {
+        self.amount == 0
+    }
+
     /// Creates a new `MoneroAmount` from a value in piconero.
     pub fn from_piconero(amount: u64) -> Self {
         MoneroAmount { amount }

--- a/libgrease/src/kes/data_objects.rs
+++ b/libgrease/src/kes/data_objects.rs
@@ -1,4 +1,6 @@
 use crate::crypto::traits::PublicKey;
+use crate::monero::data_objects::TransactionId;
+use crate::payment_channel::ChannelRole;
 use crate::state_machine::Balances;
 use serde::{Deserialize, Serialize};
 
@@ -26,5 +28,17 @@ pub struct KesInitializationResult {
 impl From<String> for KesId {
     fn from(channel_id: String) -> Self {
         KesId(channel_id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingTransaction {
+    pub role: ChannelRole,
+    pub transaction_id: TransactionId,
+}
+
+impl FundingTransaction {
+    pub fn new(role: ChannelRole, txid: impl Into<String>) -> Self {
+        FundingTransaction { role, transaction_id: TransactionId::new(txid) }
     }
 }

--- a/libgrease/src/kes/mod.rs
+++ b/libgrease/src/kes/mod.rs
@@ -4,5 +4,5 @@ pub mod dummy_impl;
 pub mod error;
 mod traits;
 
-pub use data_objects::{KesInitializationRecord, KesInitializationResult, PartialEncryptedKey};
+pub use data_objects::{FundingTransaction, KesInitializationRecord, KesInitializationResult, PartialEncryptedKey};
 pub use traits::KeyEscrowService;

--- a/libgrease/src/state_machine/error.rs
+++ b/libgrease/src/state_machine/error.rs
@@ -18,6 +18,8 @@ pub enum InvalidProposal {
     IncompatibleRoles,
     #[error("Mismatched initial balances proposed")]
     MismatchedBalances,
+    #[error("The total value of the channel cannot be zero")]
+    ZeroTotalValue,
     #[error("The merchant's public key in the proposal does not match the one that was expected")]
     MismatchedMerchantPublicKey,
     #[error("The customer's public key in the proposal does not match the one that was expected")]

--- a/libgrease/src/state_machine/lifecycle.rs
+++ b/libgrease/src/state_machine/lifecycle.rs
@@ -1,6 +1,5 @@
 use crate::crypto::traits::PublicKey;
-use crate::kes::{KesInitializationRecord, KesInitializationResult, KeyEscrowService};
-use crate::monero::data_objects::TransactionId;
+use crate::kes::{FundingTransaction, KesInitializationRecord, KesInitializationResult, KeyEscrowService};
 use crate::monero::{MultiSigWallet, WalletState};
 use crate::payment_channel::{ActivePaymentChannel, ChannelRole};
 use crate::state_machine::closed_channel::ClosedChannelState;
@@ -51,7 +50,7 @@ where
     OnMultiSigWalletCreated,
     OnKesCreated(Box<KesInitializationResult>),
     OnKesVerified(Box<KES>),
-    OnFundingTxConfirmed(Box<TransactionId>),
+    OnFundingTxConfirmed(Box<FundingTransaction>),
     OnUpdateChannel(Box<ChannelUpdateInfo<C>>),
     OnStartClose(Box<StartCloseInfo>),
     OnForceClose(Box<ForceCloseInfo>),
@@ -255,31 +254,42 @@ where
             kes_info,
             wallet: wallet_created_state.wallet,
             kes,
+            merchant_funding_tx: None,
+            customer_funding_tx: None,
         };
         let new_state = ChannelLifeCycle::KesVerified(Box::new(kes_verified));
         Ok(new_state)
     }
 
-    fn kes_verified_to_open(self, txid: TransactionId) -> Result<Self, (Self, LifeCycleError)> {
-        let Self::KesVerified(state) = self else {
+    fn kes_verified_to_open(mut self, tx: FundingTransaction) -> Result<Self, (Self, LifeCycleError)> {
+        let Self::KesVerified(mut state) = self else {
             return Err((self, LifeCycleError::InvalidStateTransition));
         };
-        let state = *state;
-        let channel = C::new(
-            state.channel_info.channel_id.clone(),
-            state.channel_info.role,
-            state.channel_info.initial_balances,
-        );
 
-        let open_state = EstablishedChannelState {
-            channel_info: state.channel_info,
-            payment_channel: channel,
-            wallet: state.wallet,
-            kes: state.kes,
-            funding_tx: txid,
-        };
-        let new_state = ChannelLifeCycle::Open(Box::new(open_state));
-        Ok(new_state)
+        state.save_funding_transaction(tx);
+        if state.are_funding_txs_confirmed() {
+            trace!("Funding transactions confirmed. Transitioning to EstablishedChannelState");
+            let state = *state;
+            let channel = C::new(
+                state.channel_info.channel_id.clone(),
+                state.channel_info.role,
+                state.channel_info.initial_balances,
+            );
+
+            let open_state = EstablishedChannelState {
+                channel_info: state.channel_info,
+                payment_channel: channel,
+                wallet: state.wallet,
+                kes: state.kes,
+                customer_funding_tx: state.customer_funding_tx.map(|tx| tx.transaction_id),
+                merchant_funding_tx: state.merchant_funding_tx.map(|tx| tx.transaction_id),
+            };
+            let new_state = ChannelLifeCycle::Open(Box::new(open_state));
+            Ok(new_state)
+        } else {
+            debug!("Funding transactions not confirmed yet");
+            Ok(Self::KesVerified(state))
+        }
     }
 
     fn update_channel(self, info: ChannelUpdateInfo<C>) -> Result<Self, (Self, LifeCycleError)> {
@@ -392,7 +402,7 @@ where
             (Establishing, OnMultiSigWalletCreated) => self.establishing_to_wallet_created(),
             (WalletCreated, OnKesCreated(kes)) => self.save_kes_info(*kes),
             (WalletCreated, OnKesVerified(kes)) => self.wallet_created_to_kes_verified(*kes),
-            (KesVerified, OnFundingTxConfirmed(txid)) => self.kes_verified_to_open(*txid),
+            (KesVerified, OnFundingTxConfirmed(tx)) => self.kes_verified_to_open(*tx),
             (Open, OnUpdateChannel(info)) => self.update_channel(*info),
             (Open, OnStartClose(info)) => self.open_to_closing(*info),
             (Open, OnForceClose(info)) => self.open_to_dispute(*info),
@@ -480,8 +490,8 @@ pub mod test {
     use crate::amount::MoneroAmount;
     use crate::crypto::keys::Curve25519PublicKey;
     use crate::kes::dummy_impl::DummyKes;
-    use crate::kes::PartialEncryptedKey;
-    use crate::monero::data_objects::{MultiSigInitInfo, MultisigKeyInfo, TransactionId};
+    use crate::kes::{FundingTransaction, PartialEncryptedKey};
+    use crate::monero::data_objects::{MultiSigInitInfo, MultisigKeyInfo};
     use crate::monero::dummy_impl::DummyWallet;
     use crate::monero::WalletState;
     use crate::payment_channel::dummy_impl::{DummyActiveChannel, DummyUpdateInfo};
@@ -514,7 +524,7 @@ pub mod test {
         let kes_pubkey =
             Curve25519PublicKey::from_hex("4dd896d542721742aff8671ba42aff0c4c846bea79065cf39a191bbeb11ea634").unwrap();
         let initial_customer_amount = MoneroAmount::from_xmr("1.25").unwrap();
-        let initial_merchant_amount = MoneroAmount::from_xmr("0.25").unwrap();
+        let initial_merchant_amount = MoneroAmount::from_xmr("0.0").unwrap();
         let initial_state = NewChannelBuilder::new(ChannelRole::Customer, my_pubkey.clone(), my_secret);
         let initial_state = initial_state
             .with_kes_public_key(kes_pubkey.clone())
@@ -600,7 +610,7 @@ pub mod test {
 
     pub async fn open_channel(mut lc: DummyLifecycle) -> DummyLifecycle {
         // The funding tx has been broadcast
-        let txid = TransactionId::new("DummyMoneroTx");
+        let txid = FundingTransaction::new(ChannelRole::Customer, "DummyMoneroTx");
         let event = LifeCycleEvent::OnFundingTxConfirmed(Box::new(txid));
         lc = ChannelLifeCycle::log_and_consolidate(lc.stage(), lc.handle_event(event).await);
         assert_eq!(lc.stage(), LifecycleStage::Open);
@@ -691,7 +701,7 @@ pub mod test {
         lc = successful_close(lc).await;
         let final_balance = lc.closed_channel().unwrap().final_balance();
         assert_eq!(final_balance.customer, MoneroAmount::from_xmr("0.65").unwrap());
-        assert_eq!(final_balance.merchant, MoneroAmount::from_xmr("0.85").unwrap());
+        assert_eq!(final_balance.merchant, MoneroAmount::from_xmr("0.60").unwrap());
     }
 
     #[tokio::test]
@@ -764,7 +774,7 @@ pub mod test {
         lc = uncontested_force_close(lc).await;
         let final_balance = lc.closed_channel().unwrap().final_balance();
         assert_eq!(final_balance.customer, MoneroAmount::from_xmr("0.65").unwrap());
-        assert_eq!(final_balance.merchant, MoneroAmount::from_xmr("0.85").unwrap());
+        assert_eq!(final_balance.merchant, MoneroAmount::from_xmr("0.60").unwrap());
     }
 
     #[tokio::test]

--- a/libgrease/src/state_machine/lifecycle.rs
+++ b/libgrease/src/state_machine/lifecycle.rs
@@ -261,7 +261,7 @@ where
         Ok(new_state)
     }
 
-    fn kes_verified_to_open(mut self, tx: FundingTransaction) -> Result<Self, (Self, LifeCycleError)> {
+    fn kes_verified_to_open(self, tx: FundingTransaction) -> Result<Self, (Self, LifeCycleError)> {
         let Self::KesVerified(mut state) = self else {
             return Err((self, LifeCycleError::InvalidStateTransition));
         };

--- a/libgrease/src/state_machine/new_channel.rs
+++ b/libgrease/src/state_machine/new_channel.rs
@@ -78,6 +78,11 @@ impl<P: PublicKey> NewChannelBuilder<P> {
         let customer_initial = self.customer_amount.unwrap_or_default();
         let initial_balances = Balances::new(merchant_initial, customer_initial);
 
+        // Total balance may not be zero
+        if initial_balances.total().is_zero() {
+            return None;
+        }
+
         let (merchant_label, customer_label) = match self.channel_role {
             ChannelRole::Merchant => (self.my_label.clone().unwrap(), self.peer_label.clone().unwrap()),
             ChannelRole::Customer => (self.peer_label.clone().unwrap(), self.my_label.clone().unwrap()),
@@ -152,6 +157,9 @@ impl<P: PublicKey> NewChannelState<P> {
         debug!("Internal sanity check on proposal info");
         if self.channel_info.role != proposal.role {
             return Err(InvalidProposal::IncompatibleRoles);
+        }
+        if self.channel_info.initial_balances.total().is_zero() {
+            return Err(InvalidProposal::ZeroTotalValue);
         }
         if self.channel_info.initial_balances != proposal.initial_balances {
             return Err(InvalidProposal::MismatchedBalances);

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -39,7 +39,10 @@ where
     pub(crate) payment_channel: C,
     pub(crate) wallet: W,
     pub(crate) kes: KES,
-    pub(crate) funding_tx: TransactionId,
+    // These are only optional because if one party has an initial balance of zero, no funding transaction is required
+    // But we guarantee that at least one of them is Some
+    pub(crate) merchant_funding_tx: Option<TransactionId>,
+    pub(crate) customer_funding_tx: Option<TransactionId>,
 }
 
 impl<P, C, W, KES> EstablishedChannelState<P, C, W, KES>


### PR DESCRIPTION
This PR adds the funding transaction events to the state machine and stores the tx id hashes in the state for later use.

Potentially, both the merchant and customer have to provide funding to the multisig-wallet, so the state is expanded to allow for that.

Also if the initial balance is zero, a funding transaction is not required, so that case is also handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking and confirmation logic for multiple funding transactions during channel establishment.
  - Introduced a new error message for proposals with zero total value.
- **Refactor**
  - Replaced single funding transaction handling with separate fields for merchant and customer funding transactions.
  - Enhanced event and state handling to support role-specific funding transactions.
- **Bug Fixes**
  - Enforced validation to prevent creation or acceptance of channels with zero total funds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->