### PR TITLE
feat: ergonomic serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ This will kick off the channel negotiation procedure. This includes:
 * The establishment of a new 2-of-2 multisig Monero wallet.
 * The establishment as validation of a new Key Escrow service.
 * The sharing of encrypted keys and channel state information.
+* Watching for confirmation of the funding transaction on the Monero blockchain.
 
 If you have set the `RUST_LOG` environment variable to `info`, you will see the channel negotiation process in the logs.
 

--- a/libgrease/src/helpers.rs
+++ b/libgrease/src/helpers.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+pub fn to_hex<S>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    hex::encode(bytes).serialize(s)
+}
+
+pub fn from_hex<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let hex_str = String::deserialize(de)?;
+    hex::decode(hex_str).map_err(|e| serde::de::Error::custom(format!("Invalid hex string: {e}")))
+}

--- a/libgrease/src/lib.rs
+++ b/libgrease/src/lib.rs
@@ -2,6 +2,7 @@ pub mod amount;
 pub mod channel_id;
 pub mod crypto;
 pub mod file_store;
+pub mod helpers;
 pub mod kes;
 pub mod monero;
 pub mod payment_channel;

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -1,9 +1,7 @@
 use crate::amount::MoneroAmount;
 use crate::channel_id::ChannelId;
 use crate::crypto::traits::PublicKey;
-use crate::kes::{
-    FundingTransaction, KesInitializationRecord, KesInitializationResult, PartialEncryptedKey,
-};
+use crate::kes::{FundingTransaction, KesInitializationRecord, KesInitializationResult, PartialEncryptedKey};
 use crate::monero::error::MoneroWalletError;
 use crate::monero::{MoneroKeyPair, MultiSigWallet, WalletState};
 use crate::payment_channel::ActivePaymentChannel;


### PR DESCRIPTION
Use hex strings instead of u8 vecs as the serialization format for hashes.

Also change the type of merchant- and customer-ids from Vec<u8> to String, since Strings are easier to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated channel negotiation procedure documentation to clarify the requirement to watch for confirmation of the funding transaction on the Monero blockchain.

- **New Features**
  - Introduced helper functions for serializing and deserializing byte slices as hexadecimal strings.

- **Refactor**
  - Changed internal representation of merchant and customer IDs to use strings instead of byte vectors.
  - Updated serialization format for certain fields to use hex-encoded strings.

- **Tests**
  - Added tests to verify correct serialization and deserialization of channel identifiers.

- **Style**
  - Improved code formatting for import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->