### PR TITLE
feat: mvp multisig wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ venv.bak/
 # test artifacts
 /libgrease/test_data/
 circuits/node_modules/
+demo_wallet.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -66,6 +66,21 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -278,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58-monero"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +335,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,7 +361,39 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -416,6 +481,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +503,28 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "ciphersuite"
+version = "0.4.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "dalek-ff-group",
+ "digest",
+ "elliptic-curve",
+ "ff",
+ "flexible-transcript",
+ "group",
+ "k256",
+ "minimal-ed448",
+ "p256",
+ "rand_core 0.6.4",
+ "sha2",
+ "sha3",
+ "std-shims",
+ "subtle",
  "zeroize",
 ]
 
@@ -513,6 +615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,12 +679,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -618,6 +742,8 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
  "rustc_version",
  "serde",
  "subtle",
@@ -633,6 +759,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dalek-ff-group"
+version = "0.4.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "crypto-bigint",
+ "curve25519-dalek",
+ "digest",
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "rustversion",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -719,6 +861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest",
+ "hex",
+ "md-5",
+ "rand 0.8.5",
+ "sha2",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,10 +906,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "dkg"
+version = "0.5.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "borsh",
+ "chacha20",
+ "ciphersuite",
+ "dleq",
+ "flexible-transcript",
+ "multiexp",
+ "rand_core 0.6.4",
+ "schnorr-signatures",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "dleq"
+version = "0.4.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "digest",
+ "ff",
+ "flexible-transcript",
+ "group",
+ "multiexp",
+ "rand_core 0.6.4",
+ "rustversion",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -786,6 +987,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "tap",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -872,6 +1093,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1119,19 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flexible-transcript"
+version = "0.3.2"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "blake2",
+ "digest",
+ "merlin",
+ "rustversion",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -909,6 +1154,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1067,6 +1318,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1156,6 +1417,17 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1367,6 +1639,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+dependencies = [
+ "http 1.3.1",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1673,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1542,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
- "core-foundation",
+ "core-foundation 0.9.4",
  "fnv",
  "futures",
  "if-addrs",
@@ -1606,7 +1919,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "block-padding",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1685,6 +1999,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +2049,12 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
@@ -2136,10 +2477,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "minimal-ed448"
+version = "0.4.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "generic-array 1.2.0",
+ "group",
+ "rand_core 0.6.4",
+ "rustversion",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2165,6 +2543,26 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "modular-frost"
+version = "0.8.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "ciphersuite",
+ "dalek-ff-group",
+ "digest",
+ "dkg",
+ "flexible-transcript",
+ "hex",
+ "multiexp",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "schnorr-signatures",
+ "subtle",
+ "thiserror 2.0.12",
+ "zeroize",
 ]
 
 [[package]]
@@ -2205,6 +2603,188 @@ dependencies = [
 ]
 
 [[package]]
+name = "monero-address"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "monero-io",
+ "monero-primitives",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-borromean"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "monero-generators",
+ "monero-io",
+ "monero-primitives",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-bulletproofs"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "monero-generators",
+ "monero-io",
+ "monero-primitives",
+ "rand_core 0.6.4",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-clsag"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "dalek-ff-group",
+ "flexible-transcript",
+ "group",
+ "modular-frost",
+ "monero-generators",
+ "monero-io",
+ "monero-primitives",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "std-shims",
+ "subtle",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-generators"
+version = "0.4.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "dalek-ff-group",
+ "group",
+ "monero-io",
+ "sha3",
+ "std-shims",
+ "subtle",
+]
+
+[[package]]
+name = "monero-io"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "std-shims",
+]
+
+[[package]]
+name = "monero-mlsag"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "monero-generators",
+ "monero-io",
+ "monero-primitives",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-primitives"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "monero-generators",
+ "monero-io",
+ "sha3",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-rpc"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "hex",
+ "monero-address",
+ "monero-serai",
+ "serde",
+ "serde_json",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-serai"
+version = "0.1.4-alpha"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "hex-literal",
+ "monero-borromean",
+ "monero-bulletproofs",
+ "monero-clsag",
+ "monero-generators",
+ "monero-io",
+ "monero-mlsag",
+ "monero-primitives",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-simple-request-rpc"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "digest_auth",
+ "hex",
+ "monero-rpc",
+ "simple-request",
+ "tokio",
+]
+
+[[package]]
+name = "monero-wallet"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "curve25519-dalek",
+ "dalek-ff-group",
+ "flexible-transcript",
+ "group",
+ "hex",
+ "modular-frost",
+ "monero-address",
+ "monero-clsag",
+ "monero-rpc",
+ "monero-serai",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rand_distr",
+ "std-shims",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2812,19 @@ dependencies = [
  "base-x",
  "data-encoding",
  "data-encoding-macro",
+]
+
+[[package]]
+name = "multiexp"
+version = "0.4.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "rustversion",
+ "std-shims",
+ "zeroize",
 ]
 
 [[package]]
@@ -2391,6 +2984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2434,10 +3028,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+]
 
 [[package]]
 name = "parking"
@@ -2615,6 +3226,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +3377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +3439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3011,6 +3656,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,6 +3721,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schnorr-signatures"
+version = "0.5.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "ciphersuite",
+ "flexible-transcript",
+ "multiexp",
+ "rand_core 0.6.4",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,6 +3764,43 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3161,6 +3877,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3923,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple-request"
+version = "0.1.0"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3242,6 +3981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +4007,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "std-shims"
+version = "0.1.1"
+source = "git+https://github.com/serai-dex/serai.git?branch=next#4e0c58464fc4673623938335f06e2e9ea96ca8dd"
+dependencies = [
+ "hashbrown",
+ "spin",
+]
 
 [[package]]
 name = "strsim"
@@ -3304,7 +4058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3323,6 +4077,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3493,6 +4253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +4273,23 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3687,6 +4474,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "blake2",
+ "chrono",
+ "ciphersuite",
+ "dalek-ff-group",
+ "env_logger",
+ "hex",
+ "log",
+ "modular-frost",
+ "monero-rpc",
+ "monero-serai",
+ "monero-simple-request-rpc",
+ "monero-wallet",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3718,6 +4530,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -3869,6 +4682,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
@@ -4047,6 +4866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4076,6 +4904,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "libgrease",
     "grease_cli",
     "p2p",
+    "wallet",
 ]
 
 [workspace.dependencies]
@@ -13,10 +14,11 @@ libgrease = { version = "0.1.0", path = "./libgrease" }
 anyhow = { version = "1.0.96" }
 blake2 = {  version = "0.10.6"}
 clap = { version = "4.5.31" }
+chrono = { version = "0.4.41", features = ["serde"] }
+hex = { version = "0.4.3" }
 env_logger = { version = "0.11.6" }
 futures = { version = "0.3" }
 libp2p = { version = "0.55", default-features = false }
-libp2p-request-response = { version = "0.28.0", default-features = false }
 log = { version = "0.4" }
 monero = { version = "0.21.0", features = ["serde"] }
 rand = { version = "0.9.0" }

--- a/libgrease/Cargo.toml
+++ b/libgrease/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 blake2 = { workspace = true }
 curve25519-dalek = { version = "4.1.3", features = ["digest"] }
 digest = "0.10.7"
-hex = "0.4.3"
+hex = { workspace = true }
 monero = { workspace = true, features = ["serde"] }
 rand = { workspace = true }
 thiserror = "2.0.12"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+blake2 = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }
+rand_core = { version = "0.6.4" }
+tokio = { workspace = true }
+zeroize = {  version = "1.8.1" }
+rand_chacha = {  version = "0.3.1"   }
+log = "0.4.27"
+thiserror = { workspace = true }
+
+[dependencies.monero-wallet]
+version = "0.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/networks/monero/wallet"
+features = ["multisig"]
+
+[dependencies.monero-rpc]
+version = "0.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/networks/monero/rpc"
+
+[dependencies.monero-simple-request-rpc]
+version = "0.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/networks/monero/rpc/simple-request"
+
+[dependencies.monero-serai]
+version = "0.1.4-alpha"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/networks/monero"
+
+[dependencies.modular-frost]
+version = "0.8.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/crypto/frost"
+features = ["tests"]
+
+[dependencies.ciphersuite]
+version = "0.4.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/crypto/ciphersuite"
+features = ["dalek"]
+
+[dependencies.dalek-ff-group]
+version = "0.4.1"
+git = "https://github.com/serai-dex/serai.git"
+commit = "205da3fd3872c6bebaa10be9740928276376e3b4"
+branch = "next"
+#path = "../../../oss/serai/crypto/dalek-ff-group"
+
+[dev-dependencies]
+env_logger = "0.11.8"
+serde = {workspace = true}
+serde_json = {workspace = true}

--- a/wallet/examples/multisig.rs
+++ b/wallet/examples/multisig.rs
@@ -1,0 +1,150 @@
+use ciphersuite::group::ff::PrimeField;
+use dalek_ff_group::{ED25519_BASEPOINT_TABLE, EdwardsPoint, Scalar};
+use log::info;
+use monero_rpc::{Rpc, RpcError};
+use monero_serai::transaction::Transaction;
+use monero_simple_request_rpc::SimpleRequestRpc;
+use monero_wallet::address::{MoneroAddress, Network};
+use serde::Deserialize;
+use serde_json::json;
+use wallet::virtual_wallet::{
+    MultisigWallet, WalletError,
+};
+use zeroize::Zeroizing;
+
+#[tokio::main]
+async fn main() -> Result<(), WalletError> {
+    env_logger::try_init().unwrap_or_else(|_| {
+        eprintln!("Failed to initialize logger, using default settings");
+    });
+    const ALICE: &str =
+        "43i4pVer2tNFELvfFEEXxmbxpwEAAFkmgN2wdBiaRNcvYcgrzJzVyJmHtnh2PWR42JPeDVjE8SnyK3kPBEjSixMsRz8TncK";
+    // Alice generates a keypair
+    let (k_a, p_a) = keys_from("8eb8a1fd0f2c42fa7508a8883addb0860a0c5e44c1c14605abb385375c533609");
+    println!(
+        "Alice: {} / {}",
+        hex::encode(k_a.as_bytes()),
+        hex::encode(p_a.compress().as_bytes())
+    );
+    // Bob generates a keypair
+    let (k_b, p_b) = keys_from("73ee459dd8a774afdbffafe6879ebc3b925fb23ceec9ac631f4ae02acff05f07");
+    println!(
+        "Bob  : {} / {}",
+        hex::encode(k_b.as_bytes()),
+        hex::encode(p_b.compress().as_bytes())
+    );
+    // They exchange their public keys and create multisig wallets
+    let rpc = SimpleRequestRpc::new("http://localhost:25070".into()).await?;
+    let mut wallet_a = MultisigWallet::new(rpc.clone(), k_a, p_a, p_b, None)?;
+    let mut wallet_b = MultisigWallet::new(rpc.clone(), k_b, p_b, p_a, None)?;
+
+    assert_eq!(
+        wallet_a.joint_public_spend_key(),
+        wallet_b.joint_public_spend_key(),
+        "Shared spend keys should be identical"
+    );
+    println!("Multisig wallet address for Alice: {}", wallet_a.address().to_string());
+    println!("Multisig wallet address for Bob  : {}", wallet_b.address().to_string());
+
+    println!("Creating signing state machine...");
+
+    // Pay Alice's external wallet
+    let alice_wallet = MoneroAddress::from_str(Network::Mainnet, ALICE).unwrap();
+    let payment = vec![(alice_wallet, 1_000u64)]; // Placeholder for payment, should be replaced with actual payment data
+
+    // Try load outputs
+    for wallet in [&mut wallet_a, &mut wallet_b] {
+        let must_scan = match wallet.load("demo_wallet.bin") {
+            Ok(loaded) if loaded > 0 => {
+                info!("Wallet loaded successfully. {loaded} outputs found");
+                false
+            }
+            Ok(_) => {
+                info!("No outputs in wallet, starting fresh. This will take a while...");
+                true
+            }
+            Err(e) => {
+                info!("Failed to load wallet: {e}, starting fresh. This will take a while...");
+                true
+            }
+        };
+        if must_scan {
+            let outputs = wallet.scan().await?;
+            info!("{outputs} outputs found in scan");
+            let saved = wallet.save("demo_wallet.bin").map_err(|e| RpcError::InternalError(e.to_string()))?;
+            info!("Saved {saved} outputs to disk");
+        }
+    }
+
+    wallet_b.prepare(payment.clone()).await?;
+    wallet_a.prepare(payment.clone()).await?;
+
+    info!("Preprocessing step completed for both wallets");
+
+    wallet_a.partial_sign(wallet_b.my_pre_process_data().unwrap())?;
+    info!("Partial Signing completed for Alice");
+    let pp = wallet_a.my_pre_process_data().unwrap();
+    wallet_b.partial_sign(pp)?;
+    info!("Partial Signing completed for Bob");
+
+    let ss = wallet_b.my_signing_shares().unwrap();
+
+    info!("Signing shares prepared for Bob: {}", ss.len());
+
+    let tx_a = wallet_a.sign(ss)?;
+    info!("Alice's transaction signed successfully");
+    let tx_b = wallet_b.sign(wallet_a.my_signing_shares().unwrap())?;
+    info!("Bob's transaction signed successfully");
+
+    println!("Wallet transaction from Alice: {}", hex::encode(tx_a.hash()));
+    println!("Wallet transaction from Bob: {}", hex::encode(tx_b.hash()));
+
+    println!("Sighash A: {}", hex::encode(tx_a.signature_hash().unwrap()));
+    println!("Sighash B: {}", hex::encode(tx_b.signature_hash().unwrap()));
+
+    println!("weight A: {}", tx_a.weight());
+    println!("weight B: {}", tx_b.weight());
+
+    publish_transaction(wallet_a.rpc(), &tx_a).await?;
+    Ok(())
+}
+
+fn keys_from(s: &str) -> (Zeroizing<Scalar>, EdwardsPoint) {
+    let bytes = hex::decode(s).unwrap();
+    let mut repr = [0u8; 32];
+    repr.copy_from_slice(&bytes[0..32]);
+    let secret = Scalar::from_repr(repr).unwrap();
+    let public = EdwardsPoint(ED25519_BASEPOINT_TABLE * &secret.0);
+    (Zeroizing::new(secret), public)
+}
+
+fn publish_transaction(rpc: &SimpleRequestRpc, tx: &Transaction) -> impl Send + Future<Output = Result<(), RpcError>> {
+    async move {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        struct SendRawResponse {
+            status: String,
+            double_spend: bool,
+            fee_too_low: bool,
+            invalid_input: bool,
+            invalid_output: bool,
+            low_mixin: bool,
+            not_relayed: bool,
+            overspend: bool,
+            too_big: bool,
+            too_few_outputs: bool,
+            reason: String,
+        }
+
+        let res: SendRawResponse = rpc
+            .rpc_call(
+                "send_raw_transaction",
+                Some(json!({ "tx_as_hex": hex::encode(tx.serialize()), "do_sanity_checks": true })),
+            )
+            .await?;
+
+        println!("{res:?}");
+
+        Ok(())
+    }
+}

--- a/wallet/examples/rpc_demo.rs
+++ b/wallet/examples/rpc_demo.rs
@@ -1,0 +1,63 @@
+use chrono::DateTime;
+use monero_rpc::Rpc;
+use monero_serai::block::Block;
+use monero_simple_request_rpc::SimpleRequestRpc;
+use monero_wallet::address::{MoneroAddress, Network};
+use tokio;
+use wallet::connect_to_rpc;
+
+/// Create a new RPC connection, print the block height, and exit.
+#[tokio::main]
+async fn main() {
+    match connect_to_rpc("http://localhost:25070").await {
+        Ok(rpc) => {
+            // Successfully connected to the RPC, now we can use it
+            println!("Connected to RPC successfully.");
+            let height = rpc.get_height().await.unwrap_or_else(|e| {
+                eprintln!("Failed to get block height: {}", e);
+                0
+            });
+            for i in 1..height {
+                rpc.get_block_by_number(i)
+                    .await
+                    .map(|block| {
+                        if block.transactions.len() > 0 || i % 100 == 0 {
+                            println!("{}", print_block(&block));
+                        }
+                    })
+                    .unwrap_or_else(|e| {
+                        eprintln!("Failed to get block {}: {}", i, e);
+                    });
+            }
+            println!("Current height: {height}");
+            mine_blocks(&rpc, 100).await;
+        }
+        Err(e) => {
+            eprintln!("Failed to connect to RPC: {}", e);
+        }
+    }
+}
+
+const ALICE: &str = "43i4pVer2tNFELvfFEEXxmbxpwEAAFkmgN2wdBiaRNcvYcgrzJzVyJmHtnh2PWR42JPeDVjE8SnyK3kPBEjSixMsRz8TncK";
+
+async fn mine_blocks(rpc: &SimpleRequestRpc, count: usize) {
+    let address = MoneroAddress::from_str(Network::Mainnet, ALICE).unwrap();
+    match rpc.generate_blocks(&address, count).await {
+        Ok((blocks, last_block)) => {
+            println!("Mined {} blocks. Last block {last_block}", blocks.len());
+        }
+        Err(e) => {
+            eprintln!("Failed to mine blocks: {}", e);
+        }
+    }
+}
+
+fn print_block(block: &Block) -> String {
+    format!(
+        "Block #{} {} {}\n{} transactions",
+        block.number().unwrap(),
+        DateTime::from_timestamp(block.header.timestamp as i64, 0).unwrap().to_rfc2822(),
+        hex::encode(block.hash()),
+        block.transactions.len()
+    )
+}

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod utils;
+pub mod virtual_wallet;
+
+use monero_simple_request_rpc::SimpleRequestRpc;
+
+pub async fn connect_to_rpc(rpc_server: impl Into<String>) -> Result<SimpleRequestRpc, monero_rpc::RpcError> {
+    let rpc = SimpleRequestRpc::new(rpc_server.into()).await?;
+    Ok(rpc)
+}

--- a/wallet/src/utils.rs
+++ b/wallet/src/utils.rs
@@ -1,0 +1,116 @@
+use ciphersuite::group::ff::Field;
+use dalek_ff_group::{ED25519_BASEPOINT_TABLE, EdwardsPoint, Scalar};
+use monero_simple_request_rpc::SimpleRequestRpc;
+use monero_wallet::{
+    DEFAULT_LOCK_WINDOW, Scanner, ViewPair, WalletOutput,
+    address::{AddressType, MoneroAddress, Network},
+    block::Block,
+    ringct::RctType,
+    rpc::{FeeRate, Rpc},
+    transaction::Transaction,
+};
+use rand_core::{OsRng, RngCore};
+use std::ops::Deref;
+use zeroize::Zeroizing;
+
+pub fn keypair() -> (Zeroizing<Scalar>, EdwardsPoint) {
+    let secret = Zeroizing::new(Scalar::random(OsRng));
+    let public = EdwardsPoint(ED25519_BASEPOINT_TABLE * &secret.0);
+    (secret, public)
+}
+
+pub fn random_key() -> [u8; 32] {
+    let mut result = [0u8; 32];
+    OsRng.fill_bytes(&mut result);
+    result
+}
+
+pub fn ring_len(rct_type: RctType) -> usize {
+    match rct_type {
+        RctType::ClsagBulletproof => 11,
+        RctType::ClsagBulletproofPlus => 16,
+        _ => panic!("ring size unknown for RctType"),
+    }
+}
+
+pub fn random_address() -> (Scalar, ViewPair, MoneroAddress) {
+    let spend = Scalar::random(&mut OsRng);
+    let spend_pub = ED25519_BASEPOINT_TABLE * &spend.0;
+    let view = Zeroizing::new(Scalar::random(&mut OsRng).0);
+    (
+        spend,
+        ViewPair::new(spend_pub, view.clone()).unwrap(),
+        MoneroAddress::new(
+            Network::Mainnet,
+            AddressType::Legacy,
+            spend_pub,
+            view.deref() * ED25519_BASEPOINT_TABLE,
+        ),
+    )
+}
+
+pub async fn mine_until_unlocked(rpc: &SimpleRequestRpc, addr: &MoneroAddress, tx_hash: [u8; 32]) -> Block {
+    // mine until tx is in a block
+    let mut height = rpc.get_height().await.unwrap();
+    let mut found = false;
+    let mut block = None;
+    while !found {
+        let inner_block = rpc.get_block_by_number(height - 1).await.unwrap();
+        found = match inner_block.transactions.iter().find(|&&x| x == tx_hash) {
+            Some(_) => {
+                block = Some(inner_block);
+                true
+            }
+            None => {
+                height = rpc.generate_blocks(addr, 1).await.unwrap().1 + 1;
+                false
+            }
+        }
+    }
+
+    // Mine until tx's outputs are unlocked
+    for _ in 0..(DEFAULT_LOCK_WINDOW - 1) {
+        rpc.generate_blocks(addr, 1).await.unwrap();
+    }
+
+    block.unwrap()
+}
+
+// Mines 60 blocks and returns an unlocked miner TX output.
+pub async fn get_miner_tx_output(rpc: &SimpleRequestRpc, view: &ViewPair) -> WalletOutput {
+    let mut scanner = Scanner::new(view.clone());
+
+    // Mine 60 blocks to unlock a miner TX
+    let start = rpc.get_height().await.unwrap();
+    rpc.generate_blocks(&view.legacy_address(Network::Mainnet), 60).await.unwrap();
+
+    let block = rpc.get_block_by_number(start).await.unwrap();
+    scanner.scan(rpc.get_scannable_block(block).await.unwrap()).unwrap().ignore_additional_timelock().swap_remove(0)
+}
+
+/// Make sure the weight and fee match the expected calculation.
+pub fn check_weight_and_fee(tx: &Transaction, fee_rate: FeeRate) {
+    let Transaction::V2 { proofs: Some(proofs), .. } = tx else { panic!("TX wasn't RingCT") };
+    let fee = proofs.base.fee;
+
+    let weight = tx.weight();
+    let expected_weight = fee_rate.calculate_weight_from_fee(fee);
+    assert_eq!(weight, expected_weight);
+
+    let expected_fee = fee_rate.calculate_fee_from_weight(weight);
+    assert_eq!(fee, expected_fee);
+}
+
+/// Sets up a local Monero network by creating a new RPC connection to a running node at `url` and then mining to 110
+/// blocks if necessary to ensure decoy availability.
+pub async fn setup_localnet(url: &str, addr: &MoneroAddress) -> SimpleRequestRpc {
+    let rpc = SimpleRequestRpc::new(url.to_string()).await.unwrap();
+    const BLOCKS_TO_MINE: usize = 110;
+    // Only run once
+    if rpc.get_height().await.unwrap() > BLOCKS_TO_MINE {
+        return rpc;
+    }
+    // Mine enough blocks to ensure decoy availability
+    rpc.generate_blocks(&addr, BLOCKS_TO_MINE).await.unwrap();
+    rpc
+}

--- a/wallet/src/virtual_wallet.rs
+++ b/wallet/src/virtual_wallet.rs
@@ -1,0 +1,415 @@
+use blake2::Digest;
+use dalek_ff_group::dalek::constants::ED25519_BASEPOINT_POINT;
+use dalek_ff_group::{EdwardsPoint, Scalar, dalek::Scalar as DScalar};
+use modular_frost::curve::{Ciphersuite, Ed25519};
+use monero_simple_request_rpc::SimpleRequestRpc;
+use rand_chacha::ChaCha20Rng;
+use std::collections::HashMap;
+use std::ops::Mul;
+use std::path::Path;
+use zeroize::Zeroizing;
+
+use log::debug;
+use modular_frost::dkg::DkgError;
+use modular_frost::dkg::musig::musig;
+use modular_frost::sign::{Preprocess, PreprocessMachine, SignMachine, SignatureMachine, SignatureShare};
+use modular_frost::{FrostError, Participant, ThresholdKeys, ThresholdParams};
+use monero_rpc::{FeeRate, Rpc, RpcError, ScannableBlock};
+use monero_serai::block::Block;
+use monero_serai::ringct::RctType;
+use monero_serai::ringct::clsag::ClsagAddendum;
+use monero_serai::transaction::Transaction;
+use monero_wallet::address::{AddressType, MoneroAddress, Network, SubaddressIndex};
+use monero_wallet::send::{
+    Change, SendError, SignableTransaction, TransactionSignMachine, TransactionSignatureMachine,
+};
+use monero_wallet::{OutputWithDecoys, Scanner, ViewPair, WalletOutput};
+use rand_core::{OsRng, SeedableRng};
+use thiserror::Error;
+
+pub type Commitment = Preprocess<Ed25519, ClsagAddendum>;
+
+#[derive(Debug, Clone, Error)]
+pub enum WalletError {
+    #[error("RPC Error: {0}")]
+    RpcError(#[from] RpcError),
+    #[error("Key Error: {0}")]
+    KeyError(String),
+    #[error("Not enough funds in wallet, or blockchain needs to be scanned")]
+    InsufficientFunds,
+    #[error("Transaction creation error: {0}")]
+    SendError(#[from] SendError),
+    #[error("Multisig protocol error: {0}")]
+    FrostError(#[from] FrostError),
+}
+pub struct MultisigWallet {
+    rpc: SimpleRequestRpc,
+    my_spend_key: Zeroizing<Scalar>,
+    my_public_key: EdwardsPoint,
+    sorted_pubkeys: [EdwardsPoint; 2],
+    musig_keys: ThresholdKeys<Ed25519>,
+    joint_private_view_key: Zeroizing<Scalar>,
+    joint_public_view_key: EdwardsPoint,
+    joint_public_spend_key: EdwardsPoint,
+    birthday: u64,
+    known_outputs: Vec<WalletOutput>,
+    preprocess_data: Option<Vec<Commitment>>,
+    sign_machine: Option<TransactionSignMachine>,
+    shares: Option<Vec<SignatureShare<Ed25519>>>,
+    final_signer: Option<TransactionSignatureMachine>,
+}
+
+impl MultisigWallet {
+    pub fn new(
+        rpc: SimpleRequestRpc,
+        spend_key: Zeroizing<Scalar>,
+        public_spend_key: EdwardsPoint,
+        peer_pubkey: EdwardsPoint,
+        birthday: Option<u64>,
+    ) -> Result<Self, WalletError> {
+        let mut pubkeys = [public_spend_key.clone(), peer_pubkey];
+        sort_pubkeys(&mut pubkeys);
+        let musig_keys = musig_2_of_2(&spend_key, &pubkeys)
+            .map_err(|_| WalletError::KeyError("MuSig key generation failed".into()))?;
+        let (joint_private_view_key, joint_public_view_key) = musig_dh_viewkey(&spend_key, &peer_pubkey);
+        let joint_public_spend_key = musig_keys.group_key();
+        Ok(MultisigWallet {
+            rpc,
+            my_spend_key: spend_key,
+            my_public_key: public_spend_key,
+            sorted_pubkeys: pubkeys,
+            musig_keys,
+            joint_private_view_key,
+            joint_public_view_key,
+            joint_public_spend_key,
+            birthday: birthday.unwrap_or_default(),
+            known_outputs: Vec::new(),
+            preprocess_data: None,
+            sign_machine: None,
+            shares: None,
+            final_signer: None,
+        })
+    }
+
+    pub fn address(&self) -> MoneroAddress {
+        MoneroAddress::new(
+            Network::Mainnet,
+            AddressType::Legacy,
+            self.joint_public_spend_key.0.clone(),
+            self.joint_public_view_key.0.clone(),
+        )
+    }
+    
+    pub fn my_spend_key(&self) -> &Scalar {
+        &self.my_spend_key
+    }
+
+    pub async fn get_height(&self) -> Result<u64, RpcError> {
+        self.rpc.get_height().await.map(|height| height as u64)
+    }
+
+    pub async fn get_block_by_number(&self, block_num: u64) -> Result<Block, RpcError> {
+        self.rpc.get_block_by_number(block_num as usize).await
+    }
+
+    async fn get_scannable_block(&self, block: Block) -> Result<ScannableBlock, RpcError> {
+        self.rpc.get_scannable_block(block).await
+    }
+
+    pub async fn scan(&mut self) -> Result<usize, RpcError> {
+        let k = Zeroizing::new(self.joint_private_view_key.0.clone());
+        let pair = ViewPair::new(self.joint_public_spend_key.0.clone(), k)
+            .map_err(|e| RpcError::InternalError(e.to_string()))?;
+        let mut scanner = Scanner::new(pair);
+        let height = self.get_height().await?;
+        let mut scanned = 0usize;
+        let mut found = 0usize;
+        for block_num in self.birthday..height {
+            let block = self.get_block_by_number(block_num).await?;
+            let scannable = self.get_scannable_block(block).await?;
+            let outputs = scanner.scan(scannable).map_err(|e| RpcError::InternalError(e.to_string()))?;
+            scanned += 1;
+            let outputs = outputs.not_additionally_locked();
+            if !outputs.is_empty() {
+                debug!("Scanned {} outputs for block {block_num}", outputs.len());
+                found += outputs.len();
+                self.known_outputs.extend(outputs);
+            }
+        }
+        debug!("Scanned {scanned} blocks. {found} outputs found");
+        Ok(found)
+    }
+
+    pub fn outputs(&self) -> &[WalletOutput] {
+        &self.known_outputs
+    }
+
+    pub fn rpc(&self) -> &SimpleRequestRpc {
+        &self.rpc
+    }
+
+    pub fn find_spendable_outputs(&self, min_amount: u64) -> Result<Vec<WalletOutput>, WalletError> {
+        if self.known_outputs.is_empty() {
+            return Err(WalletError::InsufficientFunds);
+        }
+        let mut result = Vec::new();
+        let mut total = 0;
+        for output in &self.known_outputs {
+            result.push(output.clone());
+            total += output.commitment().amount;
+            if total >= min_amount {
+                return Ok(result);
+            }
+        }
+        Err(WalletError::InsufficientFunds)
+    }
+
+    pub fn joint_public_spend_key(&self) -> &EdwardsPoint {
+        &self.joint_public_spend_key
+    }
+
+    pub fn get_change_output(&self) -> Result<Change, WalletError> {
+        let key = self.joint_public_spend_key().clone();
+        let vk = view_key(&key, 0);
+        let pair = ViewPair::new(key.0, vk).map_err(|e| WalletError::KeyError(e.to_string()))?;
+        let index = SubaddressIndex::new(0, 1).expect("not to fail with valid hardcoded params");
+        Ok(Change::new(pair, Some(index)))
+    }
+
+    async fn pre_process(&self, payments: Vec<(MoneroAddress, u64)>) -> Result<SignableTransaction, WalletError> {
+        const MAX_OUTPUTS: usize = 16;
+        const MINIMUM_FEE: u64 = 1_500_000;
+        // max payments must take change into account
+        if payments.len() + 1 >= MAX_OUTPUTS {
+            return Err(WalletError::SendError(SendError::TooManyOutputs));
+        }
+        if self.known_outputs.is_empty() {
+            return Err(WalletError::SendError(SendError::NoInputs));
+        }
+        let fee_rate = FeeRate::new(MINIMUM_FEE, 1000)?;
+
+        // Get reference block
+        let refblock_height = self.get_height().await? as usize - 1;
+        let block = self.rpc.get_block_by_number(refblock_height).await?;
+
+        // Determine the RCT proofs to make based off the hard fork
+        let (rct_type, ring_len) = match block.header.hardfork_version {
+            14 => (RctType::ClsagBulletproof, 10),
+            15 | 16 => (RctType::ClsagBulletproofPlus, 16),
+            _ => return Err(WalletError::SendError(SendError::UnsupportedRctType)),
+        };
+
+        let spend_total = MINIMUM_FEE + payments.iter().map(|(_, amount)| *amount).sum::<u64>();
+
+        // If this returns, there is guaranteed to be at least one input
+        let inputs = self.find_spendable_outputs(spend_total)?;
+
+        // We need a unique ID to distinguish this transaction from another transaction with an identical
+        // set of payments (as our Eventualities only match over the payments). The output's ID is
+        // guaranteed to be unique, making it satisfactory
+        let id = inputs.first().unwrap().key().compress().to_bytes();
+
+        // We need a deterministic RNG here with *some* seed. The unique ID means we don't pick some static seed
+        // It is a public value, yet that's fine as this is assumed fully transparent.
+        let mut rng = ChaCha20Rng::from_seed(id);
+        let mut inputs_actual = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            inputs_actual.push(
+                OutputWithDecoys::fingerprintable_deterministic_new(
+                    &mut rng,
+                    &self.rpc,
+                    ring_len,
+                    refblock_height,
+                    input.clone(),
+                )
+                .await?,
+            );
+        }
+        let inputs = inputs_actual;
+        // Create the change output.
+        let change = self.get_change_output()?;
+
+        let id = Zeroizing::new(id);
+        let tx = SignableTransaction::new(rct_type, id, inputs, payments, change, vec![], fee_rate)?;
+        Ok(tx)
+    }
+
+    pub async fn prepare(&mut self, payments: Vec<(MoneroAddress, u64)>) -> Result<(), WalletError> {
+        let signable = self.pre_process(payments).await?;
+        let machine = signable.multisig(self.musig_keys.clone())?;
+        let (machine, preprocess) = machine.preprocess(&mut OsRng);
+        if preprocess.len() != 1 {
+            return Err(WalletError::KeyError(format!(
+                "Expected exactly one preprocess. Got {}",
+                preprocess.len()
+            )));
+        }
+        debug!("Pre-processing complete with: {} commitments", preprocess.len());
+        self.preprocess_data = Some(preprocess);
+        self.sign_machine = Some(machine);
+        Ok(())
+    }
+
+    pub fn my_pre_process_data(&self) -> Option<Vec<Commitment>> {
+        self.preprocess_data.clone()
+    }
+
+    pub fn partial_sign(&mut self, peer_data: Vec<Commitment>) -> Result<(), WalletError> {
+        if self.sign_machine.is_none() || self.preprocess_data.is_none() {
+            return Err(WalletError::KeyError("Sign machine or preprocess data not initialized".into()));
+        }
+        let machine = self.sign_machine.take().unwrap();
+        debug!("peer data length: {}", peer_data.len());
+        debug!("my preprocess data length: {}", self.preprocess_data.as_ref().unwrap().len());
+        let commitments = self.assign_commitments(peer_data);
+        let (tx_machine, shares) = machine.sign(commitments, &[])?;
+        debug!("Signing completed with {} shares", shares.len());
+        self.shares = Some(shares);
+        self.final_signer = Some(tx_machine);
+        Ok(())
+    }
+
+    pub fn my_signing_shares(&self) -> Option<Vec<SignatureShare<Ed25519>>> {
+        self.shares.clone()
+    }
+
+    pub fn sign(&mut self, peer_shares: Vec<SignatureShare<Ed25519>>) -> Result<Transaction, WalletError> {
+        if self.final_signer.is_none() || self.shares.is_none() {
+            return Err(WalletError::KeyError("Final signer or shares not initialized".into()));
+        }
+        let machine = self.final_signer.take().unwrap();
+        let shares = self.assign_shares(peer_shares);
+        let tx = machine.complete(shares)?;
+        debug!("Final signing completed");
+        Ok(tx)
+    }
+
+    fn participants(&self) -> (Participant, Participant) {
+        let first = self.sorted_pubkeys[0] == self.my_public_key;
+        if first {
+            (Participant::new(1).unwrap(), Participant::new(2).unwrap())
+        } else {
+            (Participant::new(2).unwrap(), Participant::new(1).unwrap())
+        }
+    }
+
+    fn assign_commitments(&self, peer_data: Vec<Commitment>) -> HashMap<Participant, Vec<Commitment>> {
+        let mut commitments = HashMap::new();
+        let (me, them) = self.participants();
+        debug!("Assigning commitments for participants: me={:?} and they={:?}", me, them);
+        //commitments.insert(me, self.preprocess_data.clone().expect("We should have preprocess data"));
+        commitments.insert(them, peer_data);
+        commitments
+    }
+
+    fn assign_shares(
+        &self,
+        peer_shares: Vec<SignatureShare<Ed25519>>,
+    ) -> HashMap<Participant, Vec<SignatureShare<Ed25519>>> {
+        let mut shares = HashMap::new();
+        let (me, them) = self.participants();
+        debug!("Assigning commitments for participants: me={:?} and they={:?}", me, them);
+        //shares.insert(me, self.shares.clone().expect("We should have signature shares"));
+        shares.insert(them, peer_shares);
+        shares
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<usize, std::io::Error> {
+        let mut file = std::fs::File::create(path)?;
+        let mut written = 0usize;
+        for output in &self.known_outputs {
+            match output.write(&mut file) {
+                Ok(()) => written += 1,
+                Err(e) => {
+                    eprintln!("Failed to write output: {}", e);
+                }
+            }
+        }
+        Ok(written)
+    }
+
+    pub fn load<P: AsRef<Path>>(&mut self, path: P) -> Result<usize, std::io::Error> {
+        let mut file = std::fs::File::open(path)?;
+        let mut loaded = 0usize;
+        while let Ok(output) = WalletOutput::read(&mut file) {
+            self.known_outputs.push(output);
+            loaded += 1;
+        }
+        Ok(loaded)
+    }
+}
+
+pub fn threshold_params(p: &Participant) -> ThresholdParams {
+    ThresholdParams::new(2, 2, p.clone()).expect("not to fail with valid hardcoded params")
+}
+
+pub fn musig_context(keys: &[EdwardsPoint; 2]) -> [u8; 64 + 5] {
+    let mut result = [0u8; 64 + 5];
+    result[..5].copy_from_slice(b"Musig");
+    result[5..5 + 32].copy_from_slice(keys[0].compress().as_bytes());
+    result[5 + 32..5 + 64].copy_from_slice(keys[1].compress().as_bytes());
+    result
+}
+
+pub fn sort_pubkeys(keys: &mut [EdwardsPoint; 2]) {
+    keys.sort_unstable_by(|a, b| a.compress().as_bytes().cmp(&b.compress().as_bytes()));
+}
+
+pub fn musig_2_of_2(
+    secret: &Zeroizing<Scalar>,
+    sorted_pubkeys: &[EdwardsPoint; 2],
+) -> Result<ThresholdKeys<Ed25519>, DkgError<()>> {
+    let context = musig_context(sorted_pubkeys);
+    let core = musig(&context[..], secret, sorted_pubkeys)?;
+    Ok(ThresholdKeys::new(core))
+}
+
+pub fn musig_dh_viewkey(secret: &Zeroizing<Scalar>, other_key: &EdwardsPoint) -> (Zeroizing<Scalar>, EdwardsPoint) {
+    let k = (secret.0).clone();
+    let shared = other_key.0.mul(k);
+    let hashed =
+        blake2::Blake2b512::new().chain_update(b"MuSigViewKey").chain_update(shared.compress().as_bytes()).finalize();
+    let mut bytes = [0u8; 64];
+    bytes[..].copy_from_slice(hashed.as_slice());
+    let private_view_key = Scalar(DScalar::from_bytes_mod_order_wide(&bytes));
+    let public_view_key = EdwardsPoint(private_view_key.0 * ED25519_BASEPOINT_POINT);
+    (Zeroizing::new(private_view_key), public_view_key)
+}
+
+pub async fn get_highest_block(rpc: &SimpleRequestRpc) -> Result<Block, RpcError> {
+    let height = rpc.get_height().await?;
+    rpc.get_block_by_number(height - 1).await
+}
+
+pub fn view_key(spend_key: &EdwardsPoint, index: u64) -> Zeroizing<DScalar> {
+    let mut data = [0u8; 32 + 8];
+    data[..32].copy_from_slice(spend_key.compress().as_bytes());
+    data[32..].copy_from_slice(&index.to_le_bytes());
+    let k = Ed25519::hash_to_F(b"GreaseMultisig", &data);
+    Zeroizing::new(k.0)
+}
+
+//
+//     let sign = |tx: SignableTransaction| {
+//         let spend = spend.clone();
+//         let keys = keys.clone();
+//
+//         assert_eq!(&SignableTransaction::read(&mut tx.serialize().as_slice()).unwrap(), &tx);
+//
+//         let eventuality = Eventuality::from(tx.clone());
+//
+//         let tx = {
+//             let mut machines = HashMap::new();
+//             for i in (1..=2).map(|i| Participant::new(i).unwrap()) {
+//                 machines.insert(i, tx.clone().multisig(keys[&i].clone()).unwrap());
+//             }
+//
+//             modular_frost::tests::sign_without_caching(&mut OsRng, machines, &[])
+//         };
+//
+//         assert_eq!(&eventuality.extra(), &tx.prefix().extra, "eventuality extra was distinct");
+//         assert!(eventuality.matches(&tx.clone().into()), "eventuality didn't match");
+//
+//         tx
+//     };
+// }


### PR DESCRIPTION
This PR provides a MVP for a multisig wallet, using
* MuSig for 2-of-2 signature aggregation
* Serai's FROST protocol for transaction construction.

Functionality is increadibly basic right now.
A wallet can scan for, and save UTXOs that it owns. But it does not remove them when spent.

2 wallet can co-ordinate to create a new Transaction. 2 round-trips are needed:
- Generate and share preprocessing information.
- Generate and share signature shares.

Then either wallet can
- Consolidate and broadcast

See `multisig.rs` for a working example (assumes you have a node running with some funds already in the multisig address).

Closes #32 since it leverages Serai's RPC client while providing an alternative, faster, and lighter weight multisig alternative.