### PR TITLE
feat: support channel updates

### DIFF
--- a/grease_cli/src/interactive/menus.rs
+++ b/grease_cli/src/interactive/menus.rs
@@ -18,7 +18,6 @@ pub mod commands {
     pub const NAV_TO_CUSTOMER_MENU: &str = "For Customers";
     pub const NAV_TO_IDENTITY_MENU: &str = "Manage Identities";
     pub const NAV_TO_MERCHANT_MENU: &str = "For Merchants";
-    pub const PAYMENT_REQUEST: &str = "Request payment";
     pub const PAYMENT_SEND: &str = "Send payment";
     pub const PROPOSE_CHANNEL: &str = "Initiate new channel";
     pub const REMOVE_IDENTITY: &str = "Remove identity";
@@ -41,13 +40,12 @@ pub const IDENTITY_MENU: [&str; 7] = [
     EXIT,
 ];
 
-pub const CUSTOMER_MENU: [&str; 12] = [
+pub const CUSTOMER_MENU: [&str; 11] = [
     CONNECT_TO_CHANNEL,
     PROPOSE_CHANNEL,
     SUBMIT_FUNDING_TX,
     LIST_CHANNELS,
     PAYMENT_SEND,
-    PAYMENT_REQUEST,
     NAV_TO_IDENTITY_MENU,
     NAV_BACK,
     CLOSE_CHANNEL,
@@ -56,20 +54,16 @@ pub const CUSTOMER_MENU: [&str; 12] = [
     EXIT,
 ];
 
-pub const MERCHANT_MENU: [&str; 12] = [
+pub const MERCHANT_MENU: [&str; 9] = [
     CONNECT_TO_CHANNEL,
     SHARE_MERCHANT_INFO,
     LIST_CHANNELS,
-    PAYMENT_SEND,
-    PAYMENT_REQUEST,
     NAV_TO_IDENTITY_MENU,
     NAV_BACK,
     CLOSE_CHANNEL,
     FORCE_CLOSE_CHANNEL,
     DISPUTE_CHANNEL_CLOSE,
     EXIT,
-    // Debugging commands only
-    SUBMIT_FUNDING_TX,
 ];
 
 pub fn top_menu() -> &'static Menu {

--- a/libgrease/src/amount.rs
+++ b/libgrease/src/amount.rs
@@ -31,27 +31,34 @@ impl MoneroAmount {
     /// Creates a new `MoneroAmount` from a string representing whole XMR units.
     /// Returns `None` if the string is not a valid number representation.
     pub fn from_xmr(xmr: &str) -> Option<Self> {
-        let mut parts = xmr.split('.');
+        if xmr.is_empty() {
+            return None;
+        }
+        let (whole, frac_str) = match xmr.strip_prefix(".") {
+            Some(frac) => ("0", frac),
+            None => {
+                let mut parts = xmr.split('.');
+                let whole = parts.next()?;
+                let fraction = parts.next().unwrap_or("0");
+                if parts.next().is_some() {
+                    return None; // More than one decimal point is invalid
+                }
+                if fraction.len() > 12 {
+                    return None; // More than 12 decimal places is invalid
+                }
+                (whole, fraction)
+            }
+        };
         // Parse the whole part
-        let whole = parts.next()?.parse::<u64>().ok()?;
+        let whole = whole.parse::<u64>().ok()?;
         // Parse the fractional part, if it exists
-        let fraction = if let Some(frac_str) = parts.next() {
-            if parts.next().is_some() {
-                return None; // More than one decimal point is invalid
-            }
-            if frac_str.len() > 12 {
-                return None; // More than 12 decimal places is invalid
-            }
-
+        let fraction = {
             // Pad the fractional part with zeros to make it 12 digits
             let mut padded_frac = frac_str.to_string();
             while padded_frac.len() < 12 {
                 padded_frac.push('0');
             }
-
             padded_frac.parse::<u64>().ok()?
-        } else {
-            0
         };
 
         // Calculate the total amount in piconero
@@ -185,6 +192,9 @@ mod test {
         let val = MoneroAmount::from_xmr("123").unwrap();
         assert_eq!(val.to_piconero(), 123_000_000_000_000);
 
+        let val = MoneroAmount::from_xmr(".5").unwrap();
+        assert_eq!(val.to_piconero(), 500_000_000_000);
+
         let val = MoneroAmount::from_xmr("1.0001110001110");
         assert!(val.is_none());
 
@@ -195,9 +205,6 @@ mod test {
         assert!(val.is_none());
 
         let val = MoneroAmount::from_xmr("zero");
-        assert!(val.is_none());
-
-        let val = MoneroAmount::from_xmr(".5");
         assert!(val.is_none());
     }
 
@@ -229,6 +236,10 @@ mod test {
     fn test_from_xmr_valid() {
         let amount = MoneroAmount::from_xmr("1.25").unwrap();
         assert_eq!(amount.to_piconero(), 1_250_000_000_000);
+        let amount = MoneroAmount::from_xmr(".1234").unwrap();
+        assert_eq!(amount.to_piconero(), 123_400_000_000);
+        let amount = MoneroAmount::from_xmr(".001002").unwrap();
+        assert_eq!(amount.to_piconero(), 1_002_000_000);
     }
 
     #[test]
@@ -236,7 +247,6 @@ mod test {
         assert!(MoneroAmount::from_xmr("1.0001110001110").is_none());
         assert!(MoneroAmount::from_xmr("1.000.1110").is_none());
         assert!(MoneroAmount::from_xmr("zero").is_none());
-        assert!(MoneroAmount::from_xmr(".5").is_none());
     }
 
     #[test]

--- a/libgrease/src/amount.rs
+++ b/libgrease/src/amount.rs
@@ -43,12 +43,12 @@ impl MoneroAmount {
                 if parts.next().is_some() {
                     return None; // More than one decimal point is invalid
                 }
-                if fraction.len() > 12 {
-                    return None; // More than 12 decimal places is invalid
-                }
                 (whole, fraction)
             }
         };
+        if frac_str.len() > 12 {
+            return None; // More than 12 decimal places is invalid
+        }
         // Parse the whole part
         let whole = whole.parse::<u64>().ok()?;
         // Parse the fractional part, if it exists
@@ -196,6 +196,9 @@ mod test {
         assert_eq!(val.to_piconero(), 500_000_000_000);
 
         let val = MoneroAmount::from_xmr("1.0001110001110");
+        assert!(val.is_none());
+
+        let val = MoneroAmount::from_xmr(".0001110001110");
         assert!(val.is_none());
 
         let val = MoneroAmount::from_xmr("1.0001110001111");

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -158,7 +158,9 @@ impl EstablishingState {
             my_proof0: self.my_proof0.unwrap(),
             peer_proof0: self.peer_proof0.unwrap(),
             kes_proof: self.kes_proof.unwrap(),
-            current_commitment_tx_proof: vec![],
+            current_private_outputs: None,
+            current_public_outputs: None,
+            current_peer_public_outputs: None,
             update_count: 0,
         };
         Ok(open_channel)

--- a/libgrease/src/state_machine/events.rs
+++ b/libgrease/src/state_machine/events.rs
@@ -1,6 +1,6 @@
 use crate::amount::MoneroAmount;
-use crate::crypto::zk_objects::{KesProof, Proofs0, PublicProof0, ShardInfo};
-use crate::monero::data_objects::{ChannelUpdate, MultisigWalletData, TransactionId};
+use crate::crypto::zk_objects::{KesProof, Proofs0, PublicProof0, ShardInfo, UpdateInfo, UpdateProofs};
+use crate::monero::data_objects::{MultisigWalletData, TransactionId};
 use crate::state_machine::new_channel::RejectNewChannelReason;
 use crate::state_machine::timeouts::TimeoutReason;
 use crate::state_machine::ProposedChannelInfo;
@@ -18,8 +18,8 @@ pub enum LifeCycleEvent {
     KesShards(Box<ShardInfo>),
     KesCreated(Box<KesProof>),
     FundingTxConfirmed(Box<(TransactionId, MoneroAmount)>),
-    OnUpdateChannel(Box<ChannelUpdate>),
     FinalTxConfirmed(Box<TransactionId>),
+    ChannelUpdate(Box<(UpdateProofs, UpdateInfo)>),
     OnStartClose,
     OnForceClose,
     OnDisputeResolved,
@@ -36,7 +36,7 @@ impl Display for LifeCycleEvent {
             LifeCycleEvent::FundingTxConfirmed(_) => write!(f, "FundingTxConfirmed"),
             LifeCycleEvent::MyProof0Generated(_) => write!(f, "MyProof0Generated"),
             LifeCycleEvent::PeerProof0Received(_) => write!(f, "PeerProof0Received"),
-            LifeCycleEvent::OnUpdateChannel(_) => write!(f, "OnUpdateChannel"),
+            LifeCycleEvent::ChannelUpdate(u) => write!(f, "ChannelUpdate_{}", u.1.index),
             LifeCycleEvent::OnStartClose => write!(f, "OnStartClose"),
             LifeCycleEvent::RejectNewChannel(_) => write!(f, "OnRejectNewChannel"),
             LifeCycleEvent::OnForceClose => write!(f, "OnForceClose"),

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -1,35 +1,20 @@
 //! State object for an open / established payment channel.
 //!
 //! There are three events that are allowed in this state:
-//! - `ChannelUpdate`: This is used to update the channel state with new information. The channel remains in the `Established` state.
+//! - `UpdateChannel`: This is used to update the channel state with new information.
+//!   The channel remains in the `Established` state.
 //! - `ChannelClose`: This indicates a co-operative close of the channel. The channel will move to the `Closing` state.
 //! - `ChannelForceClose`: This indicates a force close of the channel, and will move the channel to the `Disputed` state.
-//!
-//! ## Updates
-//!
-//! ```mermaid
-//! sequenceDiagram
-//!         actor I as Initiator
-//!         actor R as Responder
-//!         I->>I: Generate proofs_i
-//!         I->>R: UpdateChannel<br/>(balances_i, proofs_Ii, partial_sig_Ii, tx_i)
-//!         R->>R: Verify proofs_i<br/>Generate tx_i
-//!         alt verification passes
-//!           R->>I: AcceptUpdate<br/>(balances_i, proofs_Ri, tx_i, partial_sig_Ri)
-//!         else verification fails
-//!           R->>I: UpdateFailed<br/>(reason, balance_Ri-1, proofs_Ri-1)
-//!         end
-//!         R->>R: Generate proofs_Ri
-//!         R->>I: UpdateChannel(ProofsR)
-//! ```
-//!
 //!
 
 use crate::amount::MoneroAmount;
 use crate::channel_metadata::ChannelMetadata;
-use crate::crypto::zk_objects::{KesProof, Proofs0, PublicProof0, ShardInfo};
+use crate::crypto::zk_objects::{
+    GenericScalar, KesProof, PrivateUpdateOutputs, Proofs0, PublicProof0, PublicUpdateOutputs, ShardInfo, UpdateInfo,
+    UpdateProofs,
+};
 use crate::lifecycle_impl;
-use crate::monero::data_objects::{ChannelUpdate, MultisigWalletData, TransactionId};
+use crate::monero::data_objects::{MultisigWalletData, TransactionId};
 use crate::state_machine::closing_channel::ClosingChannelState;
 use crate::state_machine::commitment_tx::CommitmentTransaction;
 use crate::state_machine::error::LifeCycleError;
@@ -49,8 +34,9 @@ pub struct EstablishedChannelState {
     pub(crate) my_proof0: Proofs0,
     pub(crate) peer_proof0: PublicProof0,
     pub(crate) kes_proof: KesProof,
-    #[serde(serialize_with = "crate::helpers::to_hex", deserialize_with = "crate::helpers::from_hex")]
-    pub(crate) current_commitment_tx_proof: Vec<u8>,
+    pub(crate) current_private_outputs: Option<PrivateUpdateOutputs>,
+    pub(crate) current_public_outputs: Option<PublicUpdateOutputs>,
+    pub(crate) current_peer_public_outputs: Option<PublicUpdateOutputs>,
     pub(crate) update_count: u64,
 }
 
@@ -70,28 +56,29 @@ impl EstablishedChannelState {
     pub fn to_channel_state(self) -> ChannelState {
         ChannelState::Open(self)
     }
-    pub fn new_transfer(&mut self, update: ChannelUpdate) -> Result<u64, LifeCycleError> {
-        if update.update_count != self.update_count + 1 {
-            return Err(LifeCycleError::MismatchedUpdateCount {
-                exp: self.update_count + 1,
-                actual: update.update_count,
-            });
-        }
-        if !self.metadata.apply_delta(update.delta) {
-            return Err(LifeCycleError::NotEnoughFunds);
-        }
-        self.current_commitment_tx_proof = update.proofs;
-        self.update_count += 1;
-        Ok(self.update_count)
-    }
 
     pub fn update_count(&self) -> u64 {
         self.update_count
     }
 
+    /// Returns the current witness for the channel. If no updates have been made, it returns the initial witness.
+    pub fn current_witness(&self) -> GenericScalar {
+        self.current_private_outputs.as_ref().map(|o| o.witness_i).unwrap_or(self.my_proof0.private_outputs.witness_0)
+    }
+
     pub fn multisig_address(&self, network: Network) -> Option<String> {
         let addr = self.multisig_wallet.address(network).to_string();
         Some(addr)
+    }
+
+    pub fn store_update(&mut self, my_proofs: UpdateProofs, peer_update: UpdateInfo) -> u64 {
+        let delta = peer_update.delta;
+        self.update_count = my_proofs.private_outputs.update_count;
+        self.current_private_outputs = Some(my_proofs.private_outputs);
+        self.current_public_outputs = Some(my_proofs.public_outputs.clone());
+        self.current_peer_public_outputs = Some(peer_update.proof.public_outputs);
+        self.metadata.apply_delta(delta);
+        self.update_count
     }
 
     #[allow(clippy::result_large_err)]

--- a/p2p/src/event_loop.rs
+++ b/p2p/src/event_loop.rs
@@ -11,9 +11,9 @@ use futures::channel::{
     oneshot,
 };
 use futures::{SinkExt, StreamExt};
-use libgrease::crypto::zk_objects::PublicProof0;
+use libgrease::crypto::zk_objects::{PublicProof0, UpdateInfo};
 use libgrease::monero::data_objects::{
-    MessageEnvelope, MultisigKeyInfo, MultisigSplitSecretsResponse, StartChannelUpdateConfirmation, TransactionRecord,
+    MessageEnvelope, MultisigKeyInfo, MultisigSplitSecretsResponse, TransactionRecord,
 };
 use libp2p::core::transport::ListenerId;
 use libp2p::core::ConnectedPoint;
@@ -209,7 +209,7 @@ event_loop!(
     Command(MultiSigSplitSecretsRequest): MsSplitSecretExchange => MsSplitSecretExchange[MultisigSplitSecretsResponse],
     Command(ConfirmMultiSigAddressRequest): ConfirmMsAddress => ConfirmMsAddress[bool],
     Command(ExchangeProof0): ExchangeProof0 => ExchangeProof0[PublicProof0],
-    Command(InitiateNewUpdate): StartChannelUpdate => ConfirmUpdate[StartChannelUpdateConfirmation]
+    Command(ChannelUpdate): ChannelUpdate => ChannelUpdate[UpdateInfo]
 );
 
 impl EventLoop {


### PR DESCRIPTION
Adds support for channel updates.

QoL improvement: Updates `from_xmr` to support leading decimales, so ".1" will parse as a valid MoneroAmount now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streamlined payment update process with a new proof exchange protocol for clearer confirmations and improved reliability.
  - Added interactive payment sending with detailed balance updates.
  - Enhanced input validation for Monero amounts, supporting fractional values starting with a decimal point (e.g., ".5" for 0.5 XMR).

- **Bug Fixes**
  - Improved parsing and validation of fractional Monero amounts for more robust input handling.

- **Refactor**
  - Simplified and unified channel update workflow, replacing complex update states with structured proofs.
  - Updated menus by removing outdated payment request and debug options for a cleaner interface.
  - Replaced previous channel update events and messages with a consolidated proof-based format.

- **Chores**
  - Introduced new data structures for zero-knowledge update proofs and related cryptographic components.
  - Extended delegate traits to support asynchronous generation and verification of update proofs.
  - Enhanced test coverage and reorganized imports to align with new update protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->