### PR TITLE
feat: broadcast final transaction

### DIFF
--- a/grease_cli/src/interactive/mod.rs
+++ b/grease_cli/src/interactive/mod.rs
@@ -152,6 +152,10 @@ impl InteractiveApp {
             debug!("Establishing channel. Checking whether we should rescan for funding transaction..");
             self.server.rescan_for_funding(&channel).await;
         }
+        if let Some(LifecycleStage::Closing) = self.channel_status {
+            debug!("Channel is closing. Rebroadcasting closing transaction..");
+            self.server.rebroadcast_closing_transaction(&channel).await?;
+        }
         Ok("Channel {channel} selected".to_string())
     }
 

--- a/libgrease/src/crypto/keys.rs
+++ b/libgrease/src/crypto/keys.rs
@@ -1,4 +1,4 @@
-use crate::crypto::zk_objects::{GenericScalar};
+use crate::crypto::zk_objects::GenericScalar;
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::{EdwardsPoint, Scalar};

--- a/libgrease/src/monero/data_objects.rs
+++ b/libgrease/src/monero/data_objects.rs
@@ -102,7 +102,7 @@ pub struct MultisigWalletData {
     pub joint_private_view_key: Curve25519Secret,
     pub joint_public_spend_key: Curve25519PublicKey,
     pub birthday: u64,
-    pub known_outputs: String,
+    pub known_outputs: Vec<Vec<u8>>,
 }
 
 impl MultisigWalletData {
@@ -133,7 +133,7 @@ impl Debug for MultisigWalletData {
             self.sorted_pubkeys[1].as_hex()
         )?;
         write!(f, "birthday: {}, ", self.birthday)?;
-        write!(f, "known_outputs: {}, ", self.known_outputs)?;
+        write!(f, "known_outputs: {}, ", self.known_outputs.len())?;
         write!(f, ")")
     }
 }

--- a/libgrease/src/state_machine/events.rs
+++ b/libgrease/src/state_machine/events.rs
@@ -1,4 +1,4 @@
-use crate::amount::{MoneroDelta};
+use crate::amount::MoneroDelta;
 use crate::crypto::zk_objects::{KesProof, Proofs0, PublicProof0, ShardInfo};
 use crate::monero::data_objects::{MultisigWalletData, TransactionId, TransactionRecord};
 use crate::state_machine::closing_channel::ChannelCloseRecord;

--- a/libgrease/src/state_machine/lifecycle.rs
+++ b/libgrease/src/state_machine/lifecycle.rs
@@ -155,6 +155,13 @@ impl ChannelState {
         }
     }
 
+    pub fn as_closing(&self) -> Result<&ClosingChannelState, LifeCycleError> {
+        match self {
+            ChannelState::Closing(ref state) => Ok(state),
+            _ => Err(LifeCycleError::invalid_state_for("Expected ClosingState")),
+        }
+    }
+
     #[allow(clippy::result_large_err)]
     pub fn to_open(self) -> Result<EstablishedChannelState, (Self, LifeCycleError)> {
         match self {
@@ -264,7 +271,7 @@ pub mod test {
             joint_public_spend_key: some_pub.clone(),
             joint_private_view_key: Curve25519Secret::random(&mut rand::rng()),
             birthday: 0,
-            known_outputs: String::default(),
+            known_outputs: Default::default(),
         }
     }
 

--- a/p2p/src/event_loop.rs
+++ b/p2p/src/event_loop.rs
@@ -210,7 +210,8 @@ event_loop!(
     Command(ExchangeProof0): ExchangeProof0 => ExchangeProof0[PublicProof0],
     Command(PrepareUpdate): PrepareUpdate => UpdatePrepared[UpdatePrepared],
     Command(CommitUpdate): CommitUpdate => UpdateCommitted[FinalizedUpdate],
-    Command(ChannelClose): ChannelClose => ChannelClose[ChannelCloseRecord]
+    Command(ChannelClose): ChannelClose => ChannelClose[ChannelCloseRecord],
+    Command(ClosingTxSent): ChannelClosed => ChannelClosed[bool]
 );
 
 impl EventLoop {

--- a/p2p/src/network_client.rs
+++ b/p2p/src/network_client.rs
@@ -8,7 +8,7 @@ use futures::Stream;
 use libgrease::crypto::zk_objects::PublicProof0;
 use libgrease::monero::data_objects::{
     FinalizedUpdate, MessageEnvelope, MultisigKeyInfo, MultisigSplitSecrets, MultisigSplitSecretsResponse,
-    TransactionRecord,
+    TransactionId, TransactionRecord,
 };
 use libgrease::state_machine::ChannelCloseRecord;
 use libp2p::identity::Keypair;
@@ -146,6 +146,7 @@ impl Client {
     grease_request!(send_update_preparation, PrepareUpdate, PrepareUpdate, UpdatePrepared);
     grease_request!(send_update_commitment, CommitUpdate, UpdateCommitted, FinalizedUpdate);
     grease_request!(send_close_request, ChannelClose, ChannelCloseRecord, ChannelCloseRecord);
+    grease_request!(notify_closing_tx, ClosingTxSent, TransactionId, bool);
 
     pub async fn wait_for_funding_tx(&mut self, name: &str) -> Result<TransactionRecord, PeerConnectionError> {
         trace!("⚡️ Waiting for funding transaction for channel {name}");

--- a/p2p/src/payment_channel.rs
+++ b/p2p/src/payment_channel.rs
@@ -534,7 +534,7 @@ mod test {
             joint_public_spend_key: some_pub.clone(),
             joint_private_view_key: Curve25519Secret::random(&mut rand::rng()),
             birthday: 0,
-            known_outputs: "".to_string(),
+            known_outputs: Default::default(),
         };
         let event = LifeCycleEvent::MultiSigWalletCreated(Box::new(wallet));
         channel.handle_event(event).unwrap();

--- a/wallet/examples/payment_channel_demo.rs
+++ b/wallet/examples/payment_channel_demo.rs
@@ -8,6 +8,7 @@ use monero_rpc::RpcError;
 use monero_serai::transaction::Transaction;
 use monero_simple_request_rpc::SimpleRequestRpc;
 use monero_wallet::address::{MoneroAddress, Network};
+use rand_core::OsRng;
 use std::mem;
 use wallet::utils::{publish_transaction, scalar_from};
 use wallet::virtual_wallet::{MultisigWallet, WalletError};
@@ -112,10 +113,10 @@ async fn main() -> Result<(), WalletError> {
     let alice_wallet = MoneroAddress::from_str(Network::Testnet, ALICE_ADDRESS).unwrap();
     let payment = vec![(alice_wallet, 1_000u64)]; // Placeholder for payment, should be replaced with actual payment data
 
-    wallet_a.prepare(payment.clone()).await?;
+    wallet_a.prepare(payment.clone(), &mut OsRng).await?;
     println!("Alice prepared");
 
-    wallet_b.prepare(payment.clone()).await?;
+    wallet_b.prepare(payment.clone(), &mut OsRng).await?;
     println!("Bob prepared");
 
     info!("Preprocessing step completed for both wallets");


### PR DESCRIPTION
The logic for publishing the closing transaction to the blockchain is added.

In order for the multisig wallet to be reconstructed deterministically, we need to provide a seeded RNG to the `prepare` function.

We use the hash of the spend key for this purpose. Will need to check that this is a secure approach.

Otherwise, end to end tests along the jhappy path work now!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for broadcasting and confirming closing transactions in payment channels, including explicit notification and rebroadcasting capabilities.
  - Introduced new message types and commands for handling channel closure notifications between peers.
  - Added new methods to access multisig wallet data, peer witness keys, and closing payment details.

- **Improvements**
  - Enhanced wallet handling to support deterministic and cryptographically secure random number generators.
  - Refined wallet serialization and deserialization for improved state persistence and recovery.
  - Improved validation and verification steps during channel closing.
  - Simplified multisig wallet output serialization and deserialization.

- **Bug Fixes**
  - Addressed minor formatting and initialization issues in tests and imports.

- **Refactor**
  - Streamlined file I/O and RNG handling in wallet operations for greater flexibility and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->