### PR TITLE
feat: cucumber channel payment

### DIFF
--- a/e2e/tests/cucumber/channel.rs
+++ b/e2e/tests/cucumber/channel.rs
@@ -5,6 +5,7 @@ use e2e::create_channel_proposal;
 use libgrease::amount::MoneroAmount;
 use libgrease::balance::Balances;
 use log::*;
+use monero::Denomination::Monero;
 use monero_address::{MoneroAddress, Network};
 
 #[given(expr = "{word} runs the grease server")]
@@ -20,7 +21,7 @@ async fn new_channel(world: &mut GreaseWorld, step: &Step, customer: String, mer
     let initial_balances = step
         .table
         .as_ref()
-        .map(|t| initial_balances_from_table(t))
+        .map(|t| balances_from_table(t))
         .unwrap_or(Balances::new(MoneroAmount::from(0), MoneroAmount::from_xmr("1.0").unwrap()));
     let proposal =
         create_channel_proposal(customer, merchant, initial_balances).expect("Failed to create channel proposal");
@@ -42,7 +43,7 @@ async fn new_channel(world: &mut GreaseWorld, step: &Step, customer: String, mer
     info!("Funds sent from {} to {}: {}", customer.name, merchant.name, amt);
 }
 
-fn initial_balances_from_table(table: &Table) -> Balances {
+fn balances_from_table(table: &Table) -> Balances {
     let mut balances = Balances::new(MoneroAmount::from(0), MoneroAmount::from(0));
     for row in table.rows.iter() {
         match (row.get(0).map(|s| s.as_str()), row.get(1)) {
@@ -67,5 +68,69 @@ async fn channel_status(world: &mut GreaseWorld, user: String, status: String) {
         channel_status.to_string().to_lowercase(),
         status.to_lowercase(),
         "Expected channel status for {channel} to be {status}, but got {channel_status}",
+    );
+}
+
+#[when(regex = r"^(\w+) (pays|refunds) (\d+\.?\d*) XMR to (\w+)(?: (\d+) times)?$")]
+async fn send_on_channel(
+    world: &mut GreaseWorld,
+    sender: String,
+    dir: String,
+    amount: String,
+    recipient: String,
+    count: String,
+) {
+    let amount = MoneroAmount::from_xmr(&amount).expect("Failed to parse amount");
+    let sender = world.users.get(&sender).expect(&format!("Sender {sender} not found in the world"));
+    let recipient = world.users.get(&recipient).expect(&format!("Sender {recipient} not found in the world"));
+    let channel = world.current_channel.clone().expect("There is no current channel");
+    let sender_server = world.servers.get(&sender.name).expect("Sender server not found in the world");
+    let count = count.parse::<usize>().unwrap_or(1);
+    for i in 0..count {
+        let result = match dir.as_str() {
+            "pays" => sender_server.server.pay(&channel, amount).await,
+            "refunds" => sender_server.server.refund(&channel, amount).await,
+            _ => unreachable!(),
+        };
+        match result {
+            Ok(r) => {
+                info!("Payment {i} successful: {r:?}");
+            }
+            Err(e) => {
+                error!("Failed to send payment from {} to {}: {}", sender.name, recipient.name, e);
+                panic!("Payment failed on attempt {i}");
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+#[then("the channel balance is")]
+async fn channel_balance(world: &mut GreaseWorld, step: &Step) {
+    let channel = world.current_channel.clone().expect("There is no current channel");
+    let server = &world.servers.values().next().expect("No server found in the world").server;
+    let metadata = server.channel_metadata(&channel).await.expect("Failed to get channel balances");
+    let balances = metadata.balances();
+    let expected_balances = balances_from_table(step.table.as_ref().expect("Table is required"));
+    assert_eq!(
+        balances.customer, expected_balances.customer,
+        "Expected customer balance to be {}, but got {}",
+        expected_balances.customer, balances.customer
+    );
+    assert_eq!(
+        balances.merchant, expected_balances.merchant,
+        "Expected merchant balance to be {}, but got {}",
+        expected_balances.merchant, balances.merchant
+    );
+}
+
+#[then(expr = "the transaction count is {int}")]
+async fn transaction_count(world: &mut GreaseWorld, count: u64) {
+    let channel = world.current_channel.clone().expect("There is no current channel");
+    let server = &world.servers.values().next().expect("No server found in the world").server;
+    let update_count = server.transaction_count(&channel).await.expect("Failed to get transaction count");
+    assert_eq!(
+        update_count, count,
+        "Expected transaction count to be {count}, but got {update_count}"
     );
 }

--- a/e2e/tests/features/happy_path.feature
+++ b/e2e/tests/features/happy_path.feature
@@ -8,7 +8,7 @@ Feature: Grease happy path
     # Mine 60 blocks to get enough decoys
     When Alice mines 100 blocks
 
-  Scenario: Grease Happy Path
+  Scenario: Grease Happy Path - one-way channel flow
     When Alice initiates a new channel with Bob
       | customer_balance  |  1.25  |
       | merchant_balance  |  0.00  |
@@ -17,3 +17,12 @@ Feature: Grease happy path
     When Alice mines 10 blocks
     When we wait 500 ms
     Then Alice sees the channel status as open
+    When Alice pays 0.1 XMR to Bob
+    Then the channel balance is
+      | customer_balance  |  1.15  |
+      | merchant_balance  |  0.1  |
+    When Alice pays 0.1 XMR to Bob 10 times
+    Then the channel balance is
+      | customer_balance  |  0.15  |
+      | merchant_balance  |  1.1  |
+    And the transaction count is 11

--- a/libgrease/src/channel_metadata.rs
+++ b/libgrease/src/channel_metadata.rs
@@ -17,6 +17,8 @@ pub struct ChannelMetadata {
     role: ChannelRole,
     /// The amount of money in the channel. For initial balances, see `channel_id.initial_balances()`
     current_balances: Balances,
+    /// The number of updates that have been made to this channel
+    update_count: u64,
     /// The channel ID
     channel_id: ChannelId,
     /// The KES identifier.
@@ -25,7 +27,14 @@ pub struct ChannelMetadata {
 
 impl ChannelMetadata {
     pub fn new(network: Network, role: ChannelRole, channel_id: ChannelId, kes_public_key: String) -> Self {
-        Self { network, role, current_balances: channel_id.initial_balance(), channel_id, kes_public_key }
+        Self {
+            network,
+            role,
+            current_balances: channel_id.initial_balance(),
+            channel_id,
+            kes_public_key,
+            update_count: 0,
+        }
     }
 
     pub fn channel_id(&self) -> &ChannelId {
@@ -40,6 +49,10 @@ impl ChannelMetadata {
         self.current_balances
     }
 
+    pub fn update_count(&self) -> u64 {
+        self.update_count
+    }
+
     pub fn network(&self) -> Network {
         self.network
     }
@@ -52,6 +65,7 @@ impl ChannelMetadata {
         match self.current_balances.apply_delta(delta) {
             Some(new_balances) => {
                 self.current_balances = new_balances;
+                self.update_count += 1;
                 true
             }
             None => false,

--- a/libgrease/src/state_machine/closing_channel.rs
+++ b/libgrease/src/state_machine/closing_channel.rs
@@ -30,7 +30,6 @@ pub struct ClosingChannelState {
     pub(crate) peer_proof0: PublicProof0,
     pub(crate) kes_proof: KesProof,
     pub(crate) last_update: UpdateRecord,
-    pub(crate) update_count: u64,
     pub(crate) final_tx: Option<TransactionId>,
 }
 

--- a/libgrease/src/state_machine/establishing_channel.rs
+++ b/libgrease/src/state_machine/establishing_channel.rs
@@ -159,7 +159,6 @@ impl EstablishingState {
             peer_proof0: self.peer_proof0.unwrap(),
             kes_proof: self.kes_proof.unwrap(),
             current_update: None,
-            update_count: 0,
         };
         Ok(open_channel)
     }


### PR DESCRIPTION
Adds steps to the cucumber tests allowing channels payments
`When Alice pays 0.1 XMR to Bob`
will initiate a payment of 0.1 XMR

You can also send multiple payments (for stress tests):
`When Alice pays 0.1 XMR to Bob 100 times`

You can also test refunds:
`When Bob refunds 0.1 XMR to Alice`

And you can check the channel status:
```gherkin
Then the channel balance is
      | customer_balance  |  1.15  |
      | merchant_balance  |  0.1  |
```

`And the transaction count is 11`.

### New methods

A new utility function in `NetworkServer` has been added: `transaction_count()`, which returns the number of updates the channel has seen.

The variable tracking this has been moved to `ChannelMetadata` since it is tightly bound to the current balance, and is useful to know regardless of the lifecycle stage of the channel.