### PR TITLE
fix: cucumber - closing transaction

### DIFF
--- a/e2e/tests/cucumber/channel.rs
+++ b/e2e/tests/cucumber/channel.rs
@@ -5,7 +5,6 @@ use e2e::create_channel_proposal;
 use libgrease::amount::MoneroAmount;
 use libgrease::balance::Balances;
 use log::*;
-use monero::Denomination::Monero;
 use monero_address::{MoneroAddress, Network};
 
 #[given(expr = "{word} runs the grease server")]
@@ -133,4 +132,12 @@ async fn transaction_count(world: &mut GreaseWorld, count: u64) {
         update_count, count,
         "Expected transaction count to be {count}, but got {update_count}"
     );
+}
+
+#[when(expr = "{word} closes the channel")]
+async fn close_channel(world: &mut GreaseWorld, user: String) {
+    let server = world.servers.get(&user).expect("Server not found in the world");
+    let channel = world.current_channel.clone().expect("There is no current channel");
+    let final_balances = server.server.close_channel(&channel).await.expect("Failed to close channel");
+    info!("Channel {channel} closed by {user}\nFinal balances: {final_balances:?}");
 }

--- a/e2e/tests/cucumber/channel.rs
+++ b/e2e/tests/cucumber/channel.rs
@@ -138,6 +138,9 @@ async fn transaction_count(world: &mut GreaseWorld, count: u64) {
 async fn close_channel(world: &mut GreaseWorld, user: String) {
     let server = world.servers.get(&user).expect("Server not found in the world");
     let channel = world.current_channel.clone().expect("There is no current channel");
+    let metadata = server.server.channel_metadata(&channel).await.expect("Failed to get channel metadata");
+    info!("{user} ({}) initiating channel close", metadata.role());
+    debug!("Channel metadata: {metadata:?}");
     let final_balances = server.server.close_channel(&channel).await.expect("Failed to close channel");
     info!("Channel {channel} closed by {user}\nFinal balances: {final_balances:?}");
 }

--- a/e2e/tests/cucumber/node.rs
+++ b/e2e/tests/cucumber/node.rs
@@ -37,7 +37,7 @@ async fn kill_node(world: &mut GreaseWorld) {
     }
 }
 
-#[when(expr = "{word} mines {int} blocks")]
+#[when(expr = "{word} mines {int} block(s)")]
 async fn mine_blocks(world: &mut GreaseWorld, who: String, count: usize) {
     let address = world.address_for(&who).expect("Unknown user");
     let rpc = get_rpc_client(world).await;

--- a/e2e/tests/cucumber/wallet.rs
+++ b/e2e/tests/cucumber/wallet.rs
@@ -1,1 +1,43 @@
+use crate::cucumber::GreaseWorld;
+use cucumber::then;
+use libgrease::amount::{MoneroAmount, MoneroDelta};
+use log::info;
+use monero_rpc::Rpc;
 
+/// Checks the LAST 10 blocks for a user receiving a specific amount of XMR.
+/// You can prefix the amount with a character to indicate a fuzzy match:
+/// - `~` for a range (e.g., `~0.1` means within 0.1 XMR of the specified amount)
+/// - `>` for greater than (e.g., `>0.1` means more than 0.1 XMR)
+/// - `<` for less than (e.g., `<0.1` means less than 0.1 XMR)
+/// If no prefix is given, it checks for an exact match.
+#[then(regex = r"^(\w+) receives ([~><])?(\d+\.?\d*) XMR$")]
+async fn user_receives_xmr(world: &mut GreaseWorld, who: String, fuzzy: String, amount: String) {
+    let user = world.users.get(&who).expect("User not found in the world");
+    let amount = MoneroAmount::from_xmr(&amount).expect("Failed to parse amount");
+    let delta = MoneroDelta::from(100_000_000_000);
+    let (min, max) = match fuzzy.as_str() {
+        "~" => (
+            amount.checked_apply_delta(-delta).unwrap(),
+            amount.checked_apply_delta(delta).unwrap(),
+        ), // Allow a small range for fuzzy matching
+        ">" => (amount, MoneroAmount::from_piconero(u64::MAX)), // Greater than
+        "<" => (MoneroAmount::from_piconero(0), amount),        // Less than
+        _ => (amount, amount),                                  // Exact match
+    };
+    let rpc = world.monero_node.as_ref().unwrap().rpc_client().await.expect("Could not get RPC client");
+    let height = rpc.get_height().await.expect("Could not get RPC height") as u64;
+    let mut wallet = user.wallet().await;
+    let output_count = wallet.scan(Some(height - 10), Some(height)).await.unwrap();
+    let result = wallet.outputs().iter().rev().take(output_count as usize).any(|output| {
+        let output_amount = MoneroAmount::from(output.commitment().amount);
+        if output_amount >= min && output_amount <= max {
+            info!("{} received {} XMR", who, output_amount);
+            true
+        } else {
+            false
+        }
+    });
+    if !result {
+        panic!("{} did not receive a payment", who);
+    }
+}

--- a/e2e/tests/features/happy_path.feature
+++ b/e2e/tests/features/happy_path.feature
@@ -21,12 +21,15 @@ Feature: Grease happy path
     Then the channel balance is
       | customer_balance  |  1.15  |
       | merchant_balance  |  0.1  |
-#    When Alice pays 0.1 XMR to Bob 10 times
-#    Then the channel balance is
-#      | customer_balance  |  0.15  |
-#      | merchant_balance  |  1.1  |
-#    And the transaction count is 11
+    When Alice pays 0.1 XMR to Bob 10 times
+    Then the channel balance is
+      | customer_balance  |  0.15  |
+      | merchant_balance  |  1.1  |
+    And the transaction count is 11
     When Alice closes the channel
     When Alice mines 1 block
-    Then Bob receives ~1.1 XMR
+    And we wait 100 ms
+    Then Alice sees the channel status as closed
+    And Bob sees the channel status as closed
+    And Bob receives ~1.1 XMR
     And Alice receives ~0.15 XMR

--- a/e2e/tests/features/happy_path.feature
+++ b/e2e/tests/features/happy_path.feature
@@ -21,12 +21,12 @@ Feature: Grease happy path
     Then the channel balance is
       | customer_balance  |  1.15  |
       | merchant_balance  |  0.1  |
-    When Alice pays 0.1 XMR to Bob 10 times
-    Then the channel balance is
-      | customer_balance  |  0.15  |
-      | merchant_balance  |  1.1  |
-    And the transaction count is 11
-    When Bob closes the channel
+#    When Alice pays 0.1 XMR to Bob 10 times
+#    Then the channel balance is
+#      | customer_balance  |  0.15  |
+#      | merchant_balance  |  1.1  |
+#    And the transaction count is 11
+    When Alice closes the channel
     When Alice mines 1 block
     Then Bob receives ~1.1 XMR
     And Alice receives ~0.15 XMR

--- a/e2e/tests/features/happy_path.feature
+++ b/e2e/tests/features/happy_path.feature
@@ -26,3 +26,7 @@ Feature: Grease happy path
       | customer_balance  |  0.15  |
       | merchant_balance  |  1.1  |
     And the transaction count is 11
+    When Bob closes the channel
+    When Alice mines 1 block
+    Then Bob receives ~1.1 XMR
+    And Alice receives ~0.15 XMR

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -18,7 +18,7 @@ use crate::monero::data_objects::{MultisigWalletData, TransactionId, Transaction
 use crate::state_machine::closing_channel::{ChannelCloseRecord, ClosingChannelState};
 use crate::state_machine::error::LifeCycleError;
 use crate::state_machine::ChannelClosedReason;
-use log::info;
+use log::*;
 use monero::{Address, Network};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -168,8 +168,8 @@ impl EstablishedChannelState {
         }
         let name = self.metadata.channel_id().name();
         info!(
-            "Initiating channel close on {name}. Final balance: {} / {}",
-            final_balance.merchant, final_balance.customer
+            "{}: Initiating channel close on {name}. Final balances: Merchant={} / Customer={}",
+            self.metadata.role(), final_balance.merchant, final_balance.customer
         );
         if self.update_count() == 0 {
             Self::finalize_with_no_updates(&mut self);

--- a/libgrease/src/state_machine/open_channel.rs
+++ b/libgrease/src/state_machine/open_channel.rs
@@ -169,7 +169,9 @@ impl EstablishedChannelState {
         let name = self.metadata.channel_id().name();
         info!(
             "{}: Initiating channel close on {name}. Final balances: Merchant={} / Customer={}",
-            self.metadata.role(), final_balance.merchant, final_balance.customer
+            self.metadata.role(),
+            final_balance.merchant,
+            final_balance.customer
         );
         if self.update_count() == 0 {
             Self::finalize_with_no_updates(&mut self);

--- a/wallet/examples/multisig.rs
+++ b/wallet/examples/multisig.rs
@@ -3,9 +3,8 @@ use log::*;
 use monero_rpc::RpcError;
 use monero_simple_request_rpc::SimpleRequestRpc;
 use monero_wallet::address::{MoneroAddress, Network};
-use rand_core::OsRng;
 use wallet::errors::WalletError;
-use wallet::multisig_wallet::{signature_share_to_bytes, MultisigWallet};
+use wallet::multisig_wallet::MultisigWallet;
 use wallet::publish_transaction;
 use wallet::watch_only::WatchOnlyWallet;
 

--- a/wallet/examples/multisig.rs
+++ b/wallet/examples/multisig.rs
@@ -1,4 +1,5 @@
 use libgrease::crypto::keys::{Curve25519PublicKey, Curve25519Secret};
+use log::*;
 use monero_rpc::RpcError;
 use monero_simple_request_rpc::SimpleRequestRpc;
 use monero_wallet::address::{MoneroAddress, Network};
@@ -8,13 +9,15 @@ use wallet::multisig_wallet::{signature_share_to_bytes, MultisigWallet};
 use wallet::publish_transaction;
 use wallet::watch_only::WatchOnlyWallet;
 
+/// To run this example, you need a Regtest Monero node running on localhost:25070.
+/// AND you need to have transferred at least 1 XMR to the address in `ALICE`.
 #[tokio::main]
 async fn main() -> Result<(), WalletError> {
     env_logger::try_init().unwrap_or_else(|_| {
         eprintln!("Failed to initialize logger, using default settings");
     });
     const ALICE: &str =
-        "43i4pVer2tNFELvfFEEXxmbxpwEAAFkmgN2wdBiaRNcvYcgrzJzVyJmHtnh2PWR42JPeDVjE8SnyK3kPBEjSixMsRz8TncK";
+        "44m9bCMPn4piJQS2gfXzTnBySotvXwFmLBGVhS6kUrN48e2Ya9heHoNVg6D9EJQgxnL4k97s5pEbcPvNEe5uW3or4UTr8wn";
 
     // Alice generates a keypair
     let (k_a, p_a) =
@@ -82,43 +85,52 @@ async fn main() -> Result<(), WalletError> {
     )
     .await;
 
-    // Wallet b is not deterministic, so we won't be able to restore this one later
-    wallet_b.prepare(payment.clone(), &mut OsRng).await?;
     let mut rng_a = wallet_a.deterministic_rng();
+    let mut rng_b = wallet_b.deterministic_rng();
     wallet_a.prepare(payment.clone(), &mut rng_a).await?;
+    wallet_b.prepare(payment.clone(), &mut rng_b).await?;
+    debug!("RNG A seed: {}", hex::encode(rng_a.get_seed()));
+    debug!("RNG B seed: {}", hex::encode(rng_b.get_seed()));
 
     println!("Preprocessing step completed for both wallets");
 
     let wallet_a_pp = wallet_a.my_pre_process_data().unwrap();
     let wallet_b_pp = wallet_b.my_pre_process_data().unwrap();
 
+    info!("Partially signing ALICE's wallet with Bob's pre-process data");
     wallet_a.partial_sign(&wallet_b_pp)?;
-    println!("Partial Signing completed for Alice");
+    println!("Partial Signing completed for Alice\n");
 
+    info!("Partially signing BOB's wallet with Bob's pre-process data");
     wallet_b.partial_sign(&wallet_a_pp)?;
-    println!("Partial Signing completed for Bob");
+    println!("Partial Signing completed for Bob\n");
 
+    // Serialize and restore the wallet.
+    info!("Se- and Deserializing Alice's wallet");
+    let data = wallet_a.serializable();
+    let mut wallet_a = MultisigWallet::from_serializable(rpc.clone(), data)?;
+    let mut rng_a = wallet_a.deterministic_rng();
+    debug!("RNG seed: {}", hex::encode(rng_a.get_seed()));
+    wallet_a.prepare(payment, &mut rng_a).await?;
+    wallet_a.partial_sign(&wallet_b_pp)?;
+    info!("Restored Alice's wallet\n");
+
+    info!("Creating adaptor signatures for Alice and Bob");
     // Create adaptor signature
     let offset_b = Curve25519Secret::random(&mut rand::rng());
     let adapted_b = wallet_b.adapt_signature(&offset_b)?;
 
-    // Test signature conversion for ss_a
-    let ss_a = wallet_a.my_signing_shares().unwrap();
-    let ss_a_bytes = signature_share_to_bytes(&ss_a);
-    let ss_a = wallet_a.bytes_to_signature_share(&ss_a_bytes)?;
-
-    // Serialize and restore the wallet.
-    let data = wallet_a.serializable();
-    let mut wallet_a = MultisigWallet::from_serializable(rpc.clone(), data)?;
-    let mut rng_a = wallet_a.deterministic_rng();
-    wallet_a.prepare(payment, &mut rng_a).await?;
-    wallet_a.partial_sign(&wallet_b_pp)?;
+    let offset_a = Curve25519Secret::random(&mut rand::rng());
+    let adapted_a = wallet_a.adapt_signature(&offset_a)?;
 
     // Alice signs with an adaptor signature
+    wallet_b.verify_adapted_signature(&adapted_a)?;
     wallet_a.verify_adapted_signature(&adapted_b)?;
     println!("Adaptor signature is valid (but can't create a valid transaction yet)");
     // Recreate the original signature share
+    let ss_a = wallet_b.extract_true_signature(&adapted_a, &offset_a)?;
     let ss_b = wallet_a.extract_true_signature(&adapted_b, &offset_b)?;
+
     let tx_a = wallet_a.sign(ss_b)?;
     println!("Alice's transaction signed successfully");
 

--- a/wallet/examples/payment_channel_demo.rs
+++ b/wallet/examples/payment_channel_demo.rs
@@ -132,11 +132,11 @@ async fn main() -> Result<(), WalletError> {
     wallet_b.partial_sign(&pp_a)?;
     info!("Partial Signing completed for Bob");
 
-    let ss_a_real = wallet_a.my_signing_shares().unwrap();
+    let ss_a_real = wallet_a.my_signing_share().unwrap();
 
     println!("{:?}", get_signatureshare_scalar(&ss_a_real));
 
-    let ss_b_real = wallet_b.my_signing_shares().unwrap();
+    let ss_b_real = wallet_b.my_signing_share().unwrap();
 
     let ss_a_encrypted = make_adapted_shares(&ss_a_real, secret_a);
     match wallet_b.sign(ss_a_encrypted.clone()) {

--- a/wallet/src/multisig_wallet.rs
+++ b/wallet/src/multisig_wallet.rs
@@ -448,7 +448,7 @@ impl MultisigWallet {
 
 /// Converts a vector of payments from the state machine into one that can be used by the wallet.
 /// Also accounts for fees.
-pub fn adapt_payments(
+pub fn translate_payments(
     unadjusted: [(UAddress, MoneroAmount); 2],
     fee: MoneroAmount,
 ) -> Result<Vec<(MoneroAddress, u64)>, WalletError> {


### PR DESCRIPTION
Adds a cucumber step to detect the closing transaction.

This let us identify and fix a bug that was causing the channel closure
to fail (sometimes). The deterministic RNG function used the wrong
heuristic (birthday - I don´t know why) which would sometimes lead to
different wallets getting different RNG seeds, but not always.

This has been rectified to used the shared private view key for the
shared 2 of 2 wallet, which should only be known to the two parties and
should also be unique per channel.

Log messages generally have been tidied up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new test steps for closing channels and verifying XMR receipt in end-to-end scenarios.
  * Enhanced test scenarios to cover channel closure, settlement, and balance verification.

* **Bug Fixes**
  * Improved test step expressions to support both singular and plural forms (e.g., "block(s)").

* **Refactor**
  * Renamed several methods and functions for clarity (e.g., `my_signing_shares` to `my_signing_share`, `adapt_payments` to `translate_payments`).
  * Adjusted deterministic RNG seed source for wallets to improve consistency.
  * Enhanced and clarified logging throughout the application and examples.

* **Style**
  * Reduced logging verbosity in wallet operations for cleaner output.

* **Tests**
  * Expanded test coverage for channel closure, settlement, and fuzzy XMR receipt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->