### PR TITLE
tests: add noir toolchain to ci

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -1,0 +1,40 @@
+name: Noir test
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  contents: read
+
+env:
+  REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+  REF: ${{ github.head_ref || github.ref_name }}
+  MINIMUM_NOIR_VERSION: v0.16.0
+
+jobs:
+  install:
+    name: Noir (CLI) install
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install pre-requisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl build-essential pkg-config libssl-dev clang cmake git jq
+      - name: Install nargo toolchain
+        run: |
+          NOIR_VERSION=nightly
+          PWD=$(pwd)
+          export NARGO_HOME="${HOME}/.nargo"
+          export PATH="$PATH:${NARGO_HOME}/bin:${HOME}/.bb:${PATH}"
+          # Install noirup
+          curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
+          noirup --version $NOIR_VERSION
+          # Install bb
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+          bbup
+
+          echo NARGO: $(nargo --version)
+          echo BB: $(bb --version)

--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Install pre-requisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl build-essential pkg-config libssl-dev clang cmake git jq
       - name: Install nargo toolchain
         run: |
           NOIR_VERSION=nightly


### PR DESCRIPTION
Add GitHub Actions workflow for Noir CLI testing

This is an intermediate GA to test that the flow works correctly

Details:

Introduced noir.yml workflow to test Noir on pull requests.

Configured the workflow to run on all branches for pull requests. Set up environment variables for repository, branch reference, and minimum Noir version.

Added a job to install Noir CLI and dependencies:
Installed required system packages (e.g., curl, clang, cmake). Installed nargo toolchain using noirup.
Installed bb toolchain using bbup.
Verified installation by printing versions of nargo and bb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new workflow to automatically install and verify the Noir and bb toolchains on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->