### PR TITLE
feat(cryptography): add MockVCOF for testing

### DIFF
--- a/libgrease/Cargo.toml
+++ b/libgrease/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+mocks = []
+default = ["mocks"]
 
 [dependencies]
 

--- a/libgrease/src/cryptography/mocks/mock_vcof.rs
+++ b/libgrease/src/cryptography/mocks/mock_vcof.rs
@@ -3,7 +3,7 @@
 //! This module provides a fast but insecure VCOF implementation that can be used in tests.
 //! It provides verifiability and consecutiveness, but NOT one-wayness.
 
-use crate::cryptography::vcof::{VcofError, VcofProofInput, VcofProofResult, VerifiableConsecutiveOnewayFunction};
+use crate::cryptography::vcof::{VcofError, VcofProofInput, VerifiableConsecutiveOnewayFunction};
 use crate::error::ReadError;
 use crate::grease_protocol::utils::{read_group_element, write_group_element, Readable};
 use crate::{XmrPoint, XmrScalar};
@@ -79,12 +79,17 @@ impl VerifiableConsecutiveOnewayFunction<Ed25519> for MockVCOF {
         _: &XmrPoint,
         _ctx: &Self::Context,
     ) -> Result<XmrScalar, VcofError> {
+        if update_count == 0 {
+            return Err(VcofError::DerivationError(
+                "update_count must be at least 1".to_string(),
+            ));
+        }
         // Compute next as H(seed_pub || update_count)
         let next = self.witness_i(update_count);
         Ok(next)
     }
 
-    fn create_proof(&self, input: &VcofProofInput<Ed25519>, ctx: &Self::Context) -> Result<Self::Proof, VcofError> {
+    fn create_proof(&self, input: &VcofProofInput<Ed25519>, _: &Self::Context) -> Result<Self::Proof, VcofError> {
         let proof = MockVcofProof { vcof: self.clone(), index: input.index };
         Ok(proof)
     }

--- a/libgrease/src/cryptography/mocks/mock_vcof.rs
+++ b/libgrease/src/cryptography/mocks/mock_vcof.rs
@@ -1,0 +1,175 @@
+//! Mock VCOF implementation for testing.
+//!
+//! This module provides a fast but insecure VCOF implementation that can be used in tests.
+//! It provides verifiability and consecutiveness, but NOT one-wayness.
+
+use crate::cryptography::vcof::{VcofError, VcofProofInput, VcofProofResult, VerifiableConsecutiveOnewayFunction};
+use crate::error::ReadError;
+use crate::grease_protocol::utils::{read_group_element, write_group_element, Readable};
+use crate::{XmrPoint, XmrScalar};
+use ciphersuite::group::GroupEncoding;
+use ciphersuite::{Ciphersuite, Ed25519};
+use modular_frost::sign::Writable;
+use monero::consensus::ReadExt;
+use std::io::{Read, Write};
+use zeroize::Zeroizing;
+
+/// A mock VCOF implementation for testing.
+///
+/// This implementation is NOT cryptographically secure - it provides no one-wayness since anyone
+/// with the seed public key can compute subsequent values. However, it does provide:
+/// - **Verifiability**: Proofs can be verified to confirm correct derivation
+/// - **Consecutiveness**: Each value depends deterministically on the seed public key and index
+///
+/// The next value is computed as: `H(seed_pub || index)` where H is a hash-to-scalar function.
+#[derive(Clone, Debug)]
+pub struct MockVCOF {
+    /// The original seed public key used for all derivations.
+    seed_pub: XmrPoint,
+}
+
+impl MockVCOF {
+    /// Create a new MockVCOF with the given seed public key.
+    pub fn new(seed_pub: XmrPoint) -> Self {
+        Self { seed_pub }
+    }
+
+    /// Hash the seed public key and index to produce a scalar.
+    pub fn witness_i(&self, index: u64) -> XmrScalar {
+        let mut bytes = self.seed_pub.to_bytes().as_ref().to_vec();
+        bytes.extend_from_slice(&index.to_le_bytes());
+        Ed25519::hash_to_F(b"MockVCOF", &bytes)
+    }
+}
+
+/// Proof for MockVCOF that stores the seed public key and index used for derivation.
+///
+/// Verification recomputes `H(seed_pub | index)` and checks that `G * result == next_pub`.
+#[derive(Clone, Debug)]
+pub struct MockVcofProof {
+    vcof: MockVCOF,
+    index: u64,
+}
+
+impl Writable for MockVcofProof {
+    fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        write_group_element::<Ed25519, _>(writer, &self.vcof.seed_pub)?;
+        writer.write_all(&self.index.to_le_bytes())
+    }
+}
+
+impl Readable for MockVcofProof {
+    fn read<R: Read + ?Sized>(reader: &mut R) -> Result<Self, ReadError> {
+        let seed_pub = read_group_element::<Ed25519, _>(reader)
+            .map_err(|_| ReadError::new("MockVcofProof", "failed to read group element"))?;
+        let vcof = MockVCOF { seed_pub };
+        let index = reader.read_u64().map_err(|e| ReadError::new("MockVcofProof", e.to_string()))?;
+        Ok(MockVcofProof { vcof, index })
+    }
+}
+
+impl VerifiableConsecutiveOnewayFunction<Ed25519> for MockVCOF {
+    type Proof = MockVcofProof;
+    type Context = ();
+
+    fn compute_next(
+        &self,
+        update_count: u64,
+        _: &XmrScalar,
+        _: &XmrPoint,
+        _ctx: &Self::Context,
+    ) -> Result<XmrScalar, VcofError> {
+        // Compute next as H(seed_pub || update_count)
+        let next = self.witness_i(update_count);
+        Ok(next)
+    }
+
+    fn create_proof(&self, input: &VcofProofInput<Ed25519>, ctx: &Self::Context) -> Result<Self::Proof, VcofError> {
+        let proof = MockVcofProof { vcof: self.clone(), index: input.index };
+        Ok(proof)
+    }
+
+    fn verify(
+        &self,
+        update_count: u64,
+        prev: &XmrPoint,
+        next: &XmrPoint,
+        proof: &Self::Proof,
+        _: &(),
+    ) -> Result<(), VcofError> {
+        if update_count < 1 {
+            return Err(VcofError::InvalidProof);
+        }
+
+        if proof.index != update_count {
+            return Err(VcofError::InvalidProof);
+        }
+
+        if update_count == 1 {
+            if *prev != self.seed_pub {
+                return Err(VcofError::InvalidProof);
+            }
+        } else {
+            let expected_prev = self.witness_i(update_count - 1);
+            let expected_prev_pub = Ed25519::generator() * expected_prev;
+
+            if expected_prev_pub != *prev {
+                return Err(VcofError::InvalidProof);
+            }
+        }
+        let expected_next = self.witness_i(update_count);
+        let expected_next_pub = Ed25519::generator() * expected_next;
+
+        if expected_next_pub != *next {
+            return Err(VcofError::InvalidProof);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Field;
+    use rand_core::OsRng;
+
+    #[test]
+    fn test_mock_vcof_consecutiveness() {
+        // Create initial seed
+        let seed = Zeroizing::new(XmrScalar::random(&mut OsRng));
+        let pub0 = Ed25519::generator() * *seed;
+        // Create initial record and VCOF instance
+
+        let vcof = MockVCOF::new(pub0.clone());
+
+        let p1 = vcof.next(1, &seed, &pub0, &()).unwrap();
+        // Advance to next record
+        assert_eq!(p1.input.index, 1);
+
+        vcof.verify(1, &p1.input.prev_pub, &p1.input.next_pub, &p1.proof, &()).unwrap();
+
+        // Advance again
+        let p2 = vcof.next(2, &p1.input.next, &p1.input.next_pub, &()).unwrap();
+        assert_eq!(p2.input.index, 2);
+        assert_eq!(p2.input.prev_pub, p1.input.next_pub);
+        vcof.verify(2, &p2.input.prev_pub, &p2.input.next_pub, &p2.proof, &()).unwrap();
+    }
+
+    #[test]
+    fn test_mock_vcof_invalid_proof() {
+        let seed = Zeroizing::new(XmrScalar::random(&mut OsRng));
+        let pub0 = Ed25519::generator() * *seed;
+        let vcof = MockVCOF::new(pub0);
+
+        let p1 = vcof.next(1, &seed, &pub0, &()).unwrap();
+
+        // Create a proof with wrong index
+        let bad_proof = MockVcofProof { vcof: vcof.clone(), index: 999 };
+        let result = vcof.verify(1, &p1.input.prev_pub, &p1.input.next_pub, &bad_proof, &());
+        assert!(matches!(result, Err(VcofError::InvalidProof)));
+
+        // Verify with wrong update_count
+        let result = vcof.verify(2, &p1.input.prev_pub, &p1.input.next_pub, &p1.proof, &());
+        assert!(matches!(result, Err(VcofError::InvalidProof)));
+    }
+}

--- a/libgrease/src/cryptography/mocks/mod.rs
+++ b/libgrease/src/cryptography/mocks/mod.rs
@@ -1,0 +1,5 @@
+/// The classes defined in this module are not intended for production use.
+/// They are simplified implementations meant to facilitate testing and development.
+pub mod mock_vcof;
+
+pub use mock_vcof::{MockVCOF, MockVcofProof};

--- a/libgrease/src/cryptography/mod.rs
+++ b/libgrease/src/cryptography/mod.rs
@@ -12,6 +12,8 @@ pub mod adapter_signature;
 pub mod dleq;
 pub mod ecdh_encrypt;
 pub mod keys;
+#[cfg(feature = "mocks")]
+pub mod mocks;
 pub mod pok;
 pub mod secret_encryption;
 pub mod vcof;

--- a/libgrease/src/cryptography/vcof.rs
+++ b/libgrease/src/cryptography/vcof.rs
@@ -53,7 +53,7 @@ where
         Ok(result)
     }
 
-    /// Verify that `next` is the valid consecutive output of applying the VCOF to `input` using this proof.
+    /// Verify that `next` is the valid consecutive output of applying the VCOF to `prev`.
     fn verify(
         &self,
         update_count: u64,
@@ -74,7 +74,7 @@ pub enum VcofError {
     DerivationError(String),
 }
 
-/// The output of a Verifiable Consecutive Oneway Function (VCOF) at a given index, along with a proof of correctness.
+/// The inputs and outputs of a Verifiable Consecutive Oneway Function (VCOF) derivation at a given index.
 pub struct VcofProofInput<SF>
 where
     SF: Ciphersuite,
@@ -83,7 +83,7 @@ where
     pub index: u64,
     /// The i-th secret value in the sequence.
     pub prev: Zeroizing<SF::F>,
-    /// The public key corresponding to the current secret value.
+    /// The public key corresponding to the previous secret value.
     pub prev_pub: SF::G,
     /// The (i+1)-th secret value in the sequence.
     pub next: Zeroizing<SF::F>,

--- a/libgrease/src/cryptography/vcof.rs
+++ b/libgrease/src/cryptography/vcof.rs
@@ -8,44 +8,60 @@ pub trait VerifiableConsecutiveOnewayFunction<SF>
 where
     SF: Ciphersuite,
 {
-    type Proof: Writable + Readable + VcofProof<SF>;
+    type Proof: Writable + Readable;
+    type Context;
 
     /// Given an input item, compute the next item in the sequence.
     ///
     /// Don't call this method directly; use `next` instead to get both the next item and its proof.
-    fn compute_next(&self, input: &VcofRecord<SF, Self::Proof>) -> Result<SF::F, VcofError>;
+    fn compute_next(
+        &self,
+        update_count: u64,
+        prev: &SF::F,
+        pub_prev: &SF::G,
+        ctx: &Self::Context,
+    ) -> Result<SF::F, VcofError>;
 
     /// Create a proof that `next` is the valid consecutive output of applying the VCOF to `input`.
     ///
     /// Don't call this method directly; use `next` instead to get both the next item and its proof.
-    fn create_proof(&self, input: &VcofRecord<SF, Self::Proof>) -> Result<Self::Proof, VcofError>;
+    fn create_proof(&self, input: &VcofProofInput<SF>, ctx: &Self::Context) -> Result<Self::Proof, VcofError>;
 
     /// Calculate the next item in the VCOF sequence along with a proof of correctness.
     ///
     /// If the proof and next value are computed atomically, you can override the default implementation, and make
     /// [`compute_next`] and [`create_proof`] no-ops.
     /// Otherwise, you need to implement [`compute_next`] and [`create_proof`] accordingly.
-    fn next(&self, input: &VcofRecord<SF, Self::Proof>) -> Result<VcofRecord<SF, Self::Proof>, VcofError> {
-        let next = Zeroizing::new(self.compute_next(input)?);
+    fn next(
+        &self,
+        update_count: u64,
+        prev: &SF::F,
+        prev_pub: &SF::G,
+        ctx: &Self::Context,
+    ) -> Result<VcofProofResult<SF, Self::Proof>, VcofError> {
+        let next = Zeroizing::new(self.compute_next(update_count, prev, prev_pub, ctx)?);
         let next_pub = SF::generator() * *next;
-        let proof = self.create_proof(input)?;
-        Ok(VcofRecord {
-            index: input.index + 1,
-            current: input.next.clone(),
-            current_pub: input.next_pub,
+        let input = VcofProofInput {
+            index: update_count,
+            prev: Zeroizing::new(prev.clone()),
+            prev_pub: prev_pub.clone(),
             next,
             next_pub,
-            proof,
-        })
+        };
+        let proof = self.create_proof(&input, ctx)?;
+        let result = VcofProofResult::new(input, proof);
+        Ok(result)
     }
-}
 
-pub trait VcofProof<SF>
-where
-    SF: Ciphersuite,
-{
     /// Verify that `next` is the valid consecutive output of applying the VCOF to `input` using this proof.
-    fn verify(&self, input: &SF::G, next: &SF::G) -> Result<(), VcofError>;
+    fn verify(
+        &self,
+        update_count: u64,
+        prev: &SF::G,
+        next: &SF::G,
+        proof: &Self::Proof,
+        ctx: &Self::Context,
+    ) -> Result<(), VcofError>;
 }
 
 #[derive(Debug, Clone, Error)]
@@ -59,51 +75,38 @@ pub enum VcofError {
 }
 
 /// The output of a Verifiable Consecutive Oneway Function (VCOF) at a given index, along with a proof of correctness.
-pub struct VcofRecord<SF, P>
+pub struct VcofProofInput<SF>
 where
     SF: Ciphersuite,
-    P: VcofProof<SF> + Writable + Readable + Sized,
 {
-    /// The index of this record in the VCOF sequence.
-    index: u64,
+    /// The index of the next record in the VCOF sequence.
+    pub index: u64,
     /// The i-th secret value in the sequence.
-    current: Zeroizing<SF::F>,
+    pub prev: Zeroizing<SF::F>,
     /// The public key corresponding to the current secret value.
-    current_pub: SF::G,
+    pub prev_pub: SF::G,
     /// The (i+1)-th secret value in the sequence.
-    next: Zeroizing<SF::F>,
+    pub next: Zeroizing<SF::F>,
     /// The public key corresponding to the next secret value.
-    next_pub: SF::G,
-    /// The proof that `next` is the valid consecutive output of applying the VCOF to `current`.
-    proof: P,
+    pub next_pub: SF::G,
 }
 
-impl<SF, P> VcofRecord<SF, P>
+pub struct VcofProofResult<SF, P>
 where
     SF: Ciphersuite,
-    P: VcofProof<SF> + Writable + Readable + Sized,
+    P: Writable + Readable + Sized,
 {
-    pub fn index(&self) -> u64 {
-        self.index
-    }
+    pub input: VcofProofInput<SF>,
+    pub proof: P,
+}
 
-    pub fn current(&self) -> &Zeroizing<SF::F> {
-        &self.current
-    }
-
-    pub fn current_pub(&self) -> &SF::G {
-        &self.current_pub
-    }
-
-    pub fn next(&self) -> &Zeroizing<SF::F> {
-        &self.next
-    }
-
-    pub fn next_pub(&self) -> &SF::G {
-        &self.next_pub
-    }
-
-    pub fn proof(&self) -> &P {
-        &self.proof
+impl<SF, P> VcofProofResult<SF, P>
+where
+    SF: Ciphersuite,
+    P: Writable + Readable + Sized,
+{
+    /// Create a new VcofRecord with the given values.
+    pub fn new(input: VcofProofInput<SF>, proof: P) -> Self {
+        Self { input, proof }
     }
 }

--- a/libgrease/src/cryptography/vcof.rs
+++ b/libgrease/src/cryptography/vcof.rs
@@ -105,7 +105,7 @@ where
     SF: Ciphersuite,
     P: Writable + Readable + Sized,
 {
-    /// Create a new VcofRecord with the given values.
+    /// Create a new `VcofProofResult` with the given values.
     pub fn new(input: VcofProofInput<SF>, proof: P) -> Self {
         Self { input, proof }
     }

--- a/libgrease/src/cryptography/vcof_snark_dleq.rs
+++ b/libgrease/src/cryptography/vcof_snark_dleq.rs
@@ -1,5 +1,5 @@
 use crate::cryptography::dleq::Dleq;
-use crate::cryptography::vcof::{VcofError, VcofProof, VcofRecord, VerifiableConsecutiveOnewayFunction};
+use crate::cryptography::vcof::{VcofError, VcofProofInput, VerifiableConsecutiveOnewayFunction};
 use crate::grease_protocol::utils::Readable;
 use ciphersuite::{Ciphersuite, Ed25519};
 use flexible_transcript::SecureDigest;
@@ -16,22 +16,6 @@ where
 {
     dleq: <Ed25519 as Dleq<SF>>::Proof,
     snark: Vec<u8>,
-}
-
-impl<SF> VcofProof<SF> for SnarkDleqProof<SF>
-where
-    SF: Curve,
-    Ed25519: Dleq<SF>,
-{
-    fn verify(&self, input: &SF::G, next: &SF::G) -> Result<(), VcofError> {
-        // Verify the DLEQ proof first
-        error!("DLEQ proof verification not implemented.");
-
-        // Verify the SNARK proof (not implemented here)
-        // You would typically call into your SNARK verification library here
-        error!("SNARK proof verification not implemented.");
-        Ok(())
-    }
 }
 
 impl<SF> Readable for SnarkDleqProof<SF>
@@ -67,13 +51,30 @@ where
     Ed25519: Dleq<SF>,
 {
     type Proof = SnarkDleqProof<SF>;
+    type Context = ();
 
-    fn compute_next(&self, input: &VcofRecord<SF, Self::Proof>) -> Result<SF::F, VcofError> {
-        let i = input.index();
+    fn compute_next(
+        &self,
+        update_count: u64,
+        prev: &SF::F,
+        pub_prev: &SF::G,
+        ctx: &Self::Context,
+    ) -> Result<SF::F, VcofError> {
         todo!()
     }
 
-    fn create_proof(&self, input: &VcofRecord<SF, Self::Proof>) -> Result<Self::Proof, VcofError> {
+    fn create_proof(&self, input: &VcofProofInput<SF>, ctx: &Self::Context) -> Result<Self::Proof, VcofError> {
+        todo!()
+    }
+
+    fn verify(
+        &self,
+        update_count: u64,
+        prev: &SF::G,
+        next: &SF::G,
+        proof: &Self::Proof,
+        ctx: &Self::Context,
+    ) -> Result<(), VcofError> {
         todo!()
     }
 }

--- a/libgrease/src/impls/tests/update_protocol.rs
+++ b/libgrease/src/impls/tests/update_protocol.rs
@@ -5,7 +5,6 @@
 use crate::cryptography::adapter_signature::AdaptedSignature;
 use crate::cryptography::keys::{Curve25519PublicKey, Curve25519Secret, PublicKey};
 use crate::cryptography::mocks::MockVCOF;
-use crate::cryptography::vcof::{VcofError, VcofProofResult, VerifiableConsecutiveOnewayFunction};
 use crate::grease_protocol::adapter_signature::AdapterSignatureHandler;
 use crate::grease_protocol::update_channel::{
     UpdatePackage, UpdateProtocolCommon, UpdateProtocolError, UpdateProtocolProposee, UpdateProtocolProposer,
@@ -14,28 +13,8 @@ use crate::payment_channel::{ChannelRole, HasRole};
 use crate::XmrScalar;
 use async_trait::async_trait;
 use ciphersuite::{Ciphersuite, Ed25519};
-use modular_frost::sign::Writable;
 use rand_core::{CryptoRng, OsRng, RngCore};
 
-/// Mock VCOF proof that always verifies
-#[derive(Clone)]
-struct MockVCOFProof {
-    data: Vec<u8>,
-}
-
-impl Writable for MockVCOFProof {
-    fn write<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writer.write_all(&self.data)
-    }
-}
-
-impl crate::grease_protocol::utils::Readable for MockVCOFProof {
-    fn read<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<Self, crate::error::ReadError> {
-        let mut data = Vec::new();
-        reader.read_to_end(&mut data).map_err(|e| crate::error::ReadError::new("MockVCOFProof", e.to_string()))?;
-        Ok(MockVCOFProof { data })
-    }
-}
 
 /// Test implementation of UpdateProtocolProposer
 struct TestUpdateProposer {


### PR DESCRIPTION
Add a mock VCOF implementation that provides verifiability and consecutiveness but not one-wayness. Useful for fast testing without cryptographic overhead.

- Add MockVCOF struct with witness_i(index) hash function
- Add MockVcofProof with serialization support
- Refactor VerifiableConsecutiveOnewayFunction trait to use VcofProofInput/VcofProofResult
- Add mocks feature flag to libgrease

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default-enabled "mocks" feature to expose testing mocks.
  * Added a testing mock for the verifiable consecutive one-way function with serialization, proof creation, and verification.

* **Refactor**
  * Redesigned the VCOF API to separate proof/input/result and introduce a verification/context flow for extensibility.

* **Tests**
  * Updated tests to use the new mock VCOF and adjusted initialization paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->